### PR TITLE
Ethereum DevCon2 Post

### DIFF
--- a/drafts/devcon/index.md
+++ b/drafts/devcon/index.md
@@ -1,0 +1,29 @@
+---
+# this is the final blog post's id (used in the directory)
+# this id is part of the url, and should only contain:
+#   letters, numbers, dashes.
+id: devcon2-shanghai
+
+breadcrumbs:
+  - {name: "devcon2-shanghai", link: "./" }
+
+# the date here should be set to the final publication date,
+# on the day it is published.
+date: TODO
+
+# this is the Title
+title: DevCon2 ShangHai
+
+# this is the name of the main author(s)
+author: TODO
+
+# technical details required for the software, don't change these.
+baseurl: ..
+template: tmpl/layouts/post.html
+collection: posts
+---
+
+This is where the blog post's body goes.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+

--- a/drafts/devcon/skeleton.md
+++ b/drafts/devcon/skeleton.md
@@ -1,0 +1,28 @@
+# Blog Post Skeleton
+
+## Title
+
+The IPFS team went to the [Ethereum DevCon2](https://ethereumfoundation.org/devcon/) in Shanghai.
+
+## Sentence description
+
+This will be a roundup of the conference.
+
+
+## Abstract
+
+The Ethereum devcon is an important event for us, because .... The IPFS team went to Shanghai to participate. We had several presentations; Juan Benet about the overall vision of IPFS, Jeromy about Go IPFS, David Dias about Libp2p, and Samuli regarding Orbit. Here, we briefly cover their presentations and demos, and also talk about some of the talks they attended.
+
+## Skeleton
+
+- Intro
+- Why Ethereum is important to Protocol Labs
+- Presentations
+  - Juans
+  - David's
+  - Whys
+  - Haads
+- Other presentations of note
+  - Summary from attendees
+- Conclusion
+- Going Forward


### PR DESCRIPTION
# What

We should have a post after DevCon 2. 
# How

This should have a summary of our talks, as well as a roundup of the conference in general. A good example of a long roundup can be found on this [ScotlandJS](https://medium.com/@YLDio/scotlandjs-2016-69ed8a588161#.pvy98q2y1) Summary I wrote for YLD, after they gave me a free ticket to go. To make it easier for you - @jbenet, @diasdavid, @whyrusleeping, @haadcode, and @jesseclay - to write this up after, I am posting the skeleton here before. Ideally, each time you go to a talk, we can have a short summary - a few sentences - dropped in here after, which will help us make a cohesive story out of everything.

Of course, we can talk about how to do this! What I want to make sure is that we don't end up in a state where we have nothing written at the end of the conference, and we're all expected to walk away with some bright shiny post.

What're your thoughts?
