### PR TITLE
add google analytics

### DIFF
--- a/tmpl/layouts/basic.html
+++ b/tmpl/layouts/basic.html
@@ -43,5 +43,13 @@
 
 </div>
 </div> <!-- container / content -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-52930282-2', 'auto');
+  ga('send', 'pageview');
+</script>
 </body>
 </html>


### PR DESCRIPTION
I agree with @lgierth's suggestion that we should make GA only load when you're viewing the content through ipfs.io gateway but in the meantime I think we need these metrics.

This is a straight copy from https://github.com/ipfs/website/blob/534c4cee29f41ff49cfbcc1196bf45cde6eb6809/ipfs.io-theme/templates/base.html#L132-L139

I'm _pretty sure_ it will work as-is but someone should double-check.