### PR TITLE
Adds a posts JSON for consumption by the IPFS homepage

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,3 +7,6 @@ relativeURLs = true
   description = "A peer-to-peer hypermedia protocol to make the web faster, safer, and more open."
   author = "Protocol Labs"
   github = "https://github.com/ipfs/blog"
+
+[outputs]
+  home = ["HTML", "RSS", "JSON"]

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,0 +1,13 @@
+{{ $length := (len .Data.Pages) -}}
+{
+    "posts" : [
+        {{ range $index, $element := first 4 (sort (where (where .Data.Pages "Section" "post") "Kind" "page") "Params.date" "desc") -}}
+        {
+            "title" : {{ .Title | jsonify }},
+            "date" : "{{ .Date.Format "02 January 2006" }}",
+            "url" : "{{ .Permalink }}",
+            "author" : "{{ .Params.author }}"
+        }{{ if ne (add $index 1) $length }},{{ end }}
+        {{ end -}}
+    ]
+}


### PR DESCRIPTION
This allows the homepage to GET and display the latest blog posts without having to parse XML.