### PR TITLE
Update head meta tags and GA code

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
 relativeURLs = true
+googleAnalytics = "UA-52930282-2"
 
 [params]
   domain = "ipfs.io"

--- a/content/index.html
+++ b/content/index.html
@@ -36,6 +36,5 @@
   </div> <!-- container / content -->
 
   {{ partial "footer.html" . }}
-
 </body>
 </html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,1 +1,1 @@
-{{ template "_internal/google_analytics_async.html" . }}
+

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,1 @@
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-52930282-2', 'auto');
-  ga('send', 'pageview');
-</script>
+{{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,22 +8,22 @@
 <!-- open graph -->
 <meta property="og:type" content="website" />
 <meta property="og:description" content="{{ $.Param "description" }}" />
-<meta property="og:title" content="{{ if isSet .Params "title" }}{{ .Params.title }}{{ else }}{{ .Site.Params.name }}{{ end }}" />
+<meta property="og:title" content="{{ $.Param "title" }}" />
 <meta property="og:site_name" content="{{ .Site.Params.name }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:locale" content="en_US">
-<meta property="og:image" content="{{ .Permalink }}img/ipfs-logo-256-ice.png" />
+<meta property="og:image" content="/img/ipfs-logo-256-ice.png" />
 <meta property="og:image:type" content="image/png" />
 <meta property="og:image:width" contentlogo="146" />
 <meta property="og:image:height" content="166" />
 <!--Twitter Cards-->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="{{ .Site.Params.name }}" />
-<meta name="twitter:title" content="{{ if isSet .Params "title" }}{{ .Params.title }}{{ else }}{{ .Site.Params.name }}{{ end }}" />
-{{ if isSet .Params "author" }}<meta name="twitter:creator" content="{{ .Params.author }}" />{{ end }}
+<meta name="twitter:title" content="{{ $.Param "title" }}" />
+<meta name="twitter:creator" content="{{ $.Param "author" }}" />
 <meta name="twitter:description" content="{{ $.Param "description" }}" />
 <meta name="twitter:domain" content="{{ .Site.Params.domain }}" />
-<meta name="twitter:image:src" content="{{ .Permalink }}img/ipfs-logo-256-ice.png" />
+<meta name="twitter:image:src" content="/img/ipfs-logo-256-ice.png" />
 
 <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" />
 <link rel="stylesheet" href="/blog-style.css" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,27 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <title>{{ $.Param "title" }}</title>
+{{ if isSet .Params "description" }}<meta name="description" content="{{ .Params.description }}" />{{ end }}
+{{ if isSet .Params "author" }}<meta name="author" content="{{ .Params.author }}" />{{ end }}
+<!-- open graph -->
+<meta property="og:type" content="website" />
+<meta property="og:description" content="{{ $.Param "description" }}" />
+<meta property="og:title" content="{{ if isSet .Params "title" }}{{ .Params.title }}{{ else }}{{ .Site.Params.name }}{{ end }}" />
+<meta property="og:site_name" content="{{ .Site.Params.name }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:locale" content="en_US">
+<meta property="og:image" content="{{ .Permalink }}img/ipfs-logo-256-ice.png" />
+<meta property="og:image:type" content="image/png" />
+<meta property="og:image:width" contentlogo="146" />
+<meta property="og:image:height" content="166" />
+<!--Twitter Cards-->
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="{{ .Site.Params.name }}" />
+<meta name="twitter:title" content="{{ if isSet .Params "title" }}{{ .Params.title }}{{ else }}{{ .Site.Params.name }}{{ end }}" />
+{{ if isSet .Params "author" }}<meta name="twitter:creator" content="{{ .Params.author }}" />{{ end }}
+<meta name="twitter:description" content="{{ $.Param "description" }}" />
+<meta name="twitter:domain" content="{{ .Site.Params.domain }}" />
+<meta name="twitter:image:src" content="{{ .Permalink }}img/ipfs-logo-256-ice.png" />
 
 <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" />
 <link rel="stylesheet" href="/blog-style.css" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -35,3 +35,4 @@
 <script src="/asciinema/asciinema-player.js"></script>
 <script src="/highlight/highlight.js"></script>
 <script>hljs.initHighlightingOnLoad()</script>
+{{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,7 +12,7 @@
 <meta property="og:site_name" content="{{ .Site.Params.name }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:locale" content="en_US">
-<meta property="og:image" content="/img/ipfs-logo-256-ice.png" />
+<meta property="og:image" content="{{ .Site.BaseURL }}img/ipfs-logo-256-ice.png" />
 <meta property="og:image:type" content="image/png" />
 <meta property="og:image:width" contentlogo="146" />
 <meta property="og:image:height" content="166" />
@@ -23,7 +23,7 @@
 <meta name="twitter:creator" content="{{ $.Param "author" }}" />
 <meta name="twitter:description" content="{{ $.Param "description" }}" />
 <meta name="twitter:domain" content="{{ .Site.Params.domain }}" />
-<meta name="twitter:image:src" content="{{ .Site.baseURL }}img/ipfs-logo-256-ice.png" />
+<meta name="twitter:image:src" content="{{ .Site.BaseURL }}img/ipfs-logo-256-ice.png" />
 
 <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" />
 <link rel="stylesheet" href="/blog-style.css" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,8 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <title>{{ $.Param "title" }}</title>
-{{ if isSet .Params "description" }}<meta name="description" content="{{ .Params.description }}" />{{ end }}
-{{ if isSet .Params "author" }}<meta name="author" content="{{ .Params.author }}" />{{ end }}
+<meta name="description" content="{{ $.Param "description" }}" />
+<meta name="author" content="{{ $.Param "author" }}" />
 <!-- open graph -->
 <meta property="og:type" content="website" />
 <meta property="og:description" content="{{ $.Param "description" }}" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,7 +23,7 @@
 <meta name="twitter:creator" content="{{ $.Param "author" }}" />
 <meta name="twitter:description" content="{{ $.Param "description" }}" />
 <meta name="twitter:domain" content="{{ .Site.Params.domain }}" />
-<meta name="twitter:image:src" content="/img/ipfs-logo-256-ice.png" />
+<meta name="twitter:image:src" content="{{ .Site.baseURL }}img/ipfs-logo-256-ice.png" />
 
 <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" />
 <link rel="stylesheet" href="/blog-style.css" />


### PR DESCRIPTION
* Adds OG and Twitter meta tags in line with the other sites.
* Uses built-in Hugo template to render async GA code in the header.