### PR TITLE
Don't add trailing comma to JSON

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,4 +1,4 @@
-{{ $length := (len .Data.Pages) -}}
+{{ $length := (len (where (where .Data.Pages "Section" "post") "Kind" "page")) -}}
 {
     "posts" : [
         {{ range $index, $element := first 4 (sort (where (where .Data.Pages "Section" "post") "Kind" "page") "Params.date" "desc") -}}
@@ -7,7 +7,7 @@
             "date" : "{{ .Date.Format "02 January 2006" }}",
             "url" : "{{ .Permalink }}",
             "author" : "{{ .Params.author }}"
-        }{{ if ne (add $index 1) $length }},{{ end }}
+        }{{ if and (ne (add $index 1) $length) (ne $index 3) }},{{ end }}
         {{ end -}}
     ]
 }


### PR DESCRIPTION
The `index.json` template now suppresses the comma after the item which is either the final post or the fourth, whichever comes first.