### PR TITLE
Add 'ready' callback to pubsub example

### DIFF
--- a/content/post/29-js-ipfs-pubsub.md
+++ b/content/post/29-js-ipfs-pubsub.md
@@ -22,7 +22,11 @@ const IPFS = require('IPFS')
 const ipfs = new IPFS({
   EXPERIMENTAL: {
     pubsub: true // required, enables pubsub
-   }
+  }
+})
+
+ipfs.once('ready', () => {
+  // node is ready
 })
 ```
 


### PR DESCRIPTION
Example modified to clarify that waiting for 'ready' callback is.