### PR TITLE
Revert change to URL

### DIFF
--- a/content/post/30-js-ipfs-crdts.md
+++ b/content/post/30-js-ipfs-crdts.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-08-01
-url: 30-js-ipfs-crdts
+url: 30-js-ipfs-crdts.md
 title: Decentralized Real-Time Collaborative Documents - Conflict-free editing in the browser using js-ipfs and CRDTs
 author: Pedro Teixeira
 ---


### PR DESCRIPTION
This was changed in https://github.com/ipfs/blog/pull/134/files#diff-e52d0fb3ee34fa19c0d281c14b1229ef as I noticed that hugo generates a file `public/30-js-ipfs-crdts.md` with HTML content when you suffix the URL with `.md` instead of the usual `public/30-js-ipfs-crdts/index.html`. I thought this wasn't resolving at all so the change was intended to fix this, which it did, but it _was_ actually resolving and I ended up breaking links to the content. It should never have been part of the re-style changeset so please accept my apologies for the error.

fixes #140