### PR TITLE
Change all docs links to new site (docs.ipfs.io)

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,12 +12,11 @@
         <div class="grid-flex-cell">
           <ul class="sitemap list-unstyled">
             <li class="sitemap-head">IPFS</li>
-            <li><a href="https://github.com/ipfs/ipfs">About</a></li>
-            <li><a href="https://ipfs.io/docs/install/">Install</a></li>
+            <li><a href="https://github.com/ipfs/ipfs">GitHub</a></li>
+            <li><a href="https://docs.ipfs.io/introduction/install/">Install</a></li>
             <li><a href="https://ipfs.io/media">Media</a></li>
-            <li><a href="https://ipfs.io/docs/">Docs</a></li>
-            <li><a href="https://ipfs.io/docs/">Code</a></li>
-            <li><a href="https://ipfs.io/docs/">Community</a></li>
+            <li><a href="https://docs.ipfs.io/">Docs</a></li>
+            <li><a href="https://docs.ipfs.io/#community">Community</a></li>
             <li><a href="/">Blog</a></li>
             <li><a href="https://ipfs.io/legal/">Legal</a></li>
           </ul>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,9 +8,9 @@
       <label for="menu-toggle">Menu</label>
       <ul class="list-unstyled list-inline cf">
         <li><a href="https://ipfs.io/">About</a></li>
-        <li><a href="https://ipfs.io/docs/install">Install</a></li>
+        <li><a href="https://docs.ipfs.io/introduction/install/">Install</a></li>
         <li><a href="https://ipfs.io/media">Media</a></li>
-        <li><a href="https://ipfs.io/docs">Docs</a></li>
+        <li><a href="https://docs.ipfs.io/">Docs</a></li>
         <li><a href="/" class="current-item">Blog</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
Our new official docs site, with much more info, is now at https://docs.ipfs.io instead of the `/docs` directory that is part of this site. This PR updates the header and footer here in the blog to match the changes we recently made to the website (ipfs/website#266) by pointing all the docs-related URLs to docs.ipfs.io instead of ipfs.io/docs.