### PR TITLE
fix: blog permalinks that work on IPNS

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,9 @@
-baseURL = "https://ipfs.io/blog"
+baseURL = "https://blog.ipfs.io"
 relativeURLs = true
 googleAnalytics = "UA-52930282-2"
 
 [params]
-  domain = "ipfs.io"
+  domain = "blog.ipfs.io"
   name = "IPFS Blog"
   title = "IPFS Blog"
   description = "A peer-to-peer hypermedia protocol to make the web faster, safer, and more open."

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,6 +29,7 @@
 <link rel="stylesheet" href="/highlight/github-gist.css" />
 <link rel="stylesheet" href="/asciinema/asciinema-player.css" />
 
+<link rel="canonical" href="{{ .Permalink }}" />
 <link rel="alternate feed" href="/index.xml" type="application/rss+xml" />
 
 <script src="/asciinema/asciinema-player.js"></script>


### PR DESCRIPTION
> Context: https://github.com/ipfs/website/issues/274#issuecomment-427210000 + https://github.com/ipfs/website/pull/275

This PR changes default URL used in permalinks in https://blog.ipfs.io/index.json and https://blog.ipfs.io/index.xml from `https://ipfs.io/blog/` to `https://blog.ipfs.io`. 

Small change but makes:

-   blog permalinks  work when loaded via IPNS
-   `blog.ipfs.io/index.json` and RSS feed useful on `ipfs.io` even when loaded over IPNS, solving errors like the one below:
    >  ![2018-10-05--01-32-46](https://user-images.githubusercontent.com/157609/46509585-e67b3b80-c843-11e8-91a7-94dbd82d2c3d.png)

It should be safe to do this, as those are used only in:
-  RSS and JSON outputs
- `meta` headers for Facebook embeds

Closes #145
