### PR TITLE
Include full text in RSS/Atom feed

### DIFF
--- a/content/post/0-hello-worlds.md
+++ b/content/post/0-hello-worlds.md
@@ -20,10 +20,10 @@ This post kicks off the official IPFS (InterPlanetary File System) Blog. This is
 
 You can't _yet_ "follow" the blog with ipfs, but we're working on it and expect to have it working soon. For now, you can follow one of these ways:
 
-- HTTP: http://ipfs.io/blog
+- HTTP: https://blog.ipfs.io
 - Git: `git clone https://github.com/ipfs/blog`
 - GitHub: click watch at https://github.com/ipfs/blog
-- RSS: [follow RSS Feed]({{ baseurl }}/rss.xml)
+- RSS: [follow RSS Feed](https://blog.ipfs.io/index.xml)
 - IPFS: [coming soon](https://github.com/ipfs/blog/issues/2)
 
 Don't miss any InterPlanetary updates!

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,6 +29,7 @@
 <link rel="stylesheet" href="/highlight/github-gist.css" />
 <link rel="stylesheet" href="/asciinema/asciinema-player.css" />
 
+<link rel="shortcut icon" href="{{ "/img/ipfs-logo-256-ice.png" | absURL  }}">
 <link rel="canonical" href="{{ .Permalink }}" />
 <link rel="alternate feed" href="/index.xml" type="application/rss+xml" />
 

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,7 +1,12 @@
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
+    <image>
+      <url>{{ "/img/ipfs-logo-256-ice.png" | absURL  }}</url>
+      <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+      <link>{{ .Permalink }}</link>
+    </image>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
@@ -12,7 +17,7 @@
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range (where (where .Site.Pages "Section" "post") "Kind" "page") }}
+    {{ range first 10 (where (where .Site.Pages "Section" "post") "Kind" "page") }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
@@ -20,6 +25,7 @@
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
+      <content:encoded>{{ `<![CDATA[` | safeHTML }}{{ .Content | safeHTML }}{{ `]]>` | safeHTML }}</content:encoded>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
Closes #188 

- Adds full text (HTML) version of posts
  - There is also a short summary for readers that support both in different views
- Full text feed grew to .5MB so I limited it to 10 latest entries, it is ~70K now
- Added missing (fav)icons
- Fixed broken links in first post

@diasdavid  are you able to smoke-test [this static snapshot](https://ipfs.io/ipfs/QmX77F8MLrqtVEaoUmZsDdMpUP6W4FJJUyKQxN7m3Gean1/index.xml) in your reader?



