### PR TITLE
fix(build): use pinned hugo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ else
 endif
 
 build: clean install lint css minify
-	$(PREPEND)hugo && \
+	$(PREPEND)$(NPMBIN)/hugo && \
 	echo "" && \
 	echo "Site built out to ./public dir"
 
 serve: install lint js css minify
-	$(PREPEND)hugo server
+	$(PREPEND)$(NPMBIN)/hugo server
 
 node_modules:
 	$(PREPEND)$(NPM) i $(APPEND)
@@ -45,7 +45,7 @@ minify-img: install
 dev: install css
 	$(PREPEND)( \
 		$(NPMBIN)/nodemon -e less --exec "$(NPMBIN)/lessc --clean-css --autoprefix less/main.less static/css/main.css" & \
-		hugo server -w \
+		$(NPMBIN)/hugo server -w \
 	)
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # IPFS Blog
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.io/)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
-> Source for the [IPFS Blog](http://ipfs.io/blog)
+> Source for the [IPFS Blog](https://blog.ipfs.io)
 
-![](https://www.evernote.com/l/AMaEbN3YfmVC-JDtlxRdFnMMbfvQjQlmU9MB/image.png)
+![ipfs-blog @ 2018-11-30](https://user-images.githubusercontent.com/157609/49290285-e21b7980-f4a6-11e8-8829-fe8977b5be34.png)
 
 #### Please Review [PIPELINE.md](./PIPELINE.md) to understand how this repo pipeline works.
 
@@ -25,21 +25,23 @@
   - [Want to hack on IPFS?](#want-to-hack-on-ipfs)
 - [License](#license)
 
-## Editing
 
 ## Install
 
-1. [Install node + npm](http://nodejs.org) and required modules.
-2. [Install hugo](https://gohugo.io/)
 
-```sh
-npm install
-```
+1. [Install node + npm](http://nodejs.org)
+2. Install required modules:
+    ```console
+    $ npm install
+    ```
+3. Run build:
+    ```console
+    $ npm run build
+    ```
 
-2. Run build.
-
-```sh
-npm run build
+**Tip:** _all-in-one_ command for steps 2-3 on unix systems:
+```console
+$ make
 ```
 
 ## Usage
@@ -69,11 +71,11 @@ Start a live reloading hugo:
 npm start
 ```
 
-Blog should not be available at http://localhost:1313/blog/
+Blog should not be available at http://localhost:1313/
 
 ### Theme
 
-The layouts follow [the example viewer](https://github.com/ipfs/examples/tree/master/webapps/example-viewer). Modify the files inside
+Modify the files inside:
 
 ```
 layouts/
@@ -82,15 +84,15 @@ static/
 
 ## Publishing Post
 
-How to publish the blog on IPFS.io.
+How to publish the blog on `blog.ipfs.io`.
 
 ### Editing
 
 1. Make a change to a file
 2. Add and commit.
-3. `make build`
+3. `$ make build`
 4. `$ ipfs add -r build`
-  Only if you want a preview for other people (you can just use `make serve`). The path is `build`, in the website and the blog.
+  Only if you want a preview for other people. The path is `build`, in the website and the blog.
   The daemon needs to be running for others to access it, or to access it through a gateway.
 5. Push to remote branch.
 6. Make a pull request to `master`.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ How to publish the blog on `blog.ipfs.io`.
 1. Make a change to a file
 2. Add and commit.
 3. `$ make build`
-4. `$ ipfs add -r build`
-  Only if you want a preview for other people. The path is `build`, in the website and the blog.
+4. `$ ipfs add -r build`  
+  You can add the "build" directory to IPFS to get a CID for your version of the blog.  
   The daemon needs to be running for others to access it, or to access it through a gateway.
 5. Push to remote branch.
 6. Make a pull request to `master`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "devDependencies": {
     "dnslink-deploy": "^1.0.7",
+    "hugo-bin": "0.18.1",
     "imagemin-cli": "^3.0.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",
@@ -12,12 +13,12 @@
     "less": "^2.7.2",
     "less-plugin-autoprefix": "^1.5.1",
     "less-plugin-clean-css": "^1.5.1",
-    "nodemon": "^1.11.0"
+    "nodemon": "^1.18.7"
   },
   "scripts": {
     "start": "hugo server -ws .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "hugo"
+    "build": "lessc --clean-css --autoprefix less/main.less static/css/main.css && hugo"
   },
   "author": "Juan Benet <juan@benet.ai> (http://juan.benet.ai/)",
   "license": "MIT"


### PR DESCRIPTION
This PR makes the same change as https://github.com/ipfs/website/pull/279 (make sure to check it as well) but for `blog.ipfs.io`:

- Automatically download and use safe version of `hugo` (v0.31.1) 
  - This fixes "no posts" error people have when building locally with Hugo >0.31.1
  - Makes local and remote build future-proof, enables us to migrate to new `hugo` without any pressure
- Bumped `nodemon` to fix event-stream issue
- Small cleanup of `README`, updated links and info that was no longer valid