### PR TITLE
Fix installation link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
       <ul class="list-unstyled list-inline cf">
         <li><a href="https://ipfs.io/">About</a></li>
         <li><a href="https://ipfs.io/#implementations">Implementations</a></li>
-        <li><a href="https://docs.ipfs.io/introduction/install/">Install</a></li>
+        <li><a href="https://docs.ipfs.io/guides/guides/install/">Install</a></li>
         <li><a href="https://docs.ipfs.io/">Docs</a></li>
         <li><a href="https://ipfs.io/team">Team</a></li>
         <li><a href="https://ipfs.io/media">Media</a></li>


### PR DESCRIPTION
Fixes the broken [installation link](https://docs.ipfs.io/introduction/install/) which currently renders the following.

![image](https://user-images.githubusercontent.com/7039523/58364109-9ef9fc00-7e74-11e9-84ed-2e5b14350f63.png)
