### PR TITLE
docs: fix typo

### DIFF
--- a/content/post/050-ipfs-camp-recap.md
+++ b/content/post/050-ipfs-camp-recap.md
@@ -80,7 +80,7 @@ David Dias & The IPFS Team
 - 🍦 All you can eat fruit ice cream made all attendees very happy.
 - 👋🏽 Textile created a [**P2P Tag Game**](https://github.com/textileio/advanced-react-native-boilerplate/blob/ipfs-tag/README.md). I believe the last person to be "it" is still looking for the next person to tag, so look out at future events!
 - 👕 The first **SWAG Trading Post** was established, an eco-responsible way of attendees picking the item of swag they love the most or trade for others, avoiding the regular Conference waste and making sure everyone can optimize.
-- 📶 The Wifi worked! Well, almost, we are sorry for that one morning hiccup. Thank you everyone (espeically the course trainers!) for coming prepared with ways to make everything work offline and distributed ❤️
+- 📶 The Wifi worked! Well, almost, we are sorry for that one morning hiccup. Thank you everyone (especially the course trainers!) for coming prepared with ways to make everything work offline and distributed ❤️
 - 📦 The **whole NPM was crammed into a box** for the first time, an homage to Jen from the IT Crowd.
 - 🔌 The power cut out for a bit, but the Space Training Station continued to operate! Offline first FTW!
 - 🤝 Many people organically found and recommended people to find at camp using [The Gathering](https://gthr.io).

--- a/content/post/050-ipfs-camp-recap.md
+++ b/content/post/050-ipfs-camp-recap.md
@@ -76,7 +76,7 @@ David Dias & The IPFS Team
 
 `Extra:` As a closing gift, here are some random interesting facts about Camp:
 
-- 😸 IPFS Camp was the 1st time the Lazer Cat bot became [**P2P Lazer Cat bot**](https://github.com/gorhgorh/ipfscatremote)
+- 😸 IPFS Camp was the 1st time the Laser Cat bot became [**P2P Laser Cat bot**](https://github.com/gorhgorh/ipfscatremote)
 - 🍦 All you can eat fruit ice cream made all attendees very happy.
 - 👋🏽 Textile created a [**P2P Tag Game**](https://github.com/textileio/advanced-react-native-boilerplate/blob/ipfs-tag/README.md). I believe the last person to be "it" is still looking for the next person to tag, so look out at future events!
 - 👕 The first **SWAG Trading Post** was established, an eco-responsible way of attendees picking the item of swag they love the most or trade for others, avoiding the regular Conference waste and making sure everyone can optimize.


### PR DESCRIPTION
I added this as a comment on the original PR but I think I did it just after it was merged..

Small typo: "laser" stands for "Light Amplification by Stimulated Emission of Radiation" so is never spelt with a "z"