### PR TITLE
Contributing link case-sensitivity fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 ### Want to hack on IPFS?
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
Old "Want to hack on IPFS?" link 404'd cause CONTRIBUTING.md was written in all lowers. It's fixed now.