### PR TITLE
Explain that postdated posts can't be previewed

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ cp 66-london-hack-week-report.md 67-incredible-adventures.md
 
 Now edit the metadata at the top of the file
 
-- `date` - the "_published at_" date, shown on the [blog index page](https://blog.ipfs.io) please update at posting time to reflect current date (if you postdate a post in advance of publication, it will not appear when you preview the site locally; only posts with current and past dates are displayed) - **required**
+- `date` - the "_published at_" date, shown on the [blog index page](https://blog.ipfs.io) - please update at posting time to reflect current date (if you postdate a post in advance of publication, it will not appear when you preview the site locally; only posts with current and past dates are displayed) - **required**
 - `author` - used to give you credit for your words - **required**
 - `title` - used as the `h1` on the post page, and the name of the post on the index page. **required**
 - `tags` - don't appear to be used right now, but set them anyone, as we'll want to add a "see more posts like this one" feature one day.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The first time you run it, it will install all the dependencies ✨, Then it wil
 
 Run it and open <http://localhost:1313/> in your browser, and start editing your new blog post.
 
-_**Note**: Blog posts are only displayed (at their own URLs and in the index) once the date listed in their YAML front matter has arrived. This means it's not possible to preview a post set to a future date._ 
+_**Note**: Blog posts are only displayed (at their own URLs and in the index) once the date listed in their YAML front matter has arrived. This means it's not possible to preview a post on localhost that is set to a future publication date._ 
 
 **Build the production site**
 
@@ -77,7 +77,7 @@ $ cp 66-london-hack-week-report.md 67-incredible-adventures.md
 
 Now edit the metadata at the top of the file
 
-- `date` - the "_published at_" date, shown on the [blog index page](https://blog.ipfs.io) please update at posting time to reflect current date (if you postdate a post in advance of publication, it will not appear when you preview the site; only posts with current and past dates are displayed) - **required**
+- `date` - the "_published at_" date, shown on the [blog index page](https://blog.ipfs.io) please update at posting time to reflect current date (if you postdate a post in advance of publication, it will not appear when you preview the site locally; only posts with current and past dates are displayed) - **required**
 - `author` - used to give you credit for your words - **required**
 - `title` - used as the `h1` on the post page, and the name of the post on the index page. **required**
 - `tags` - don't appear to be used right now, but set them anyone, as we'll want to add a "see more posts like this one" feature one day.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The first time you run it, it will install all the dependencies ✨, Then it wil
 
 Run it and open <http://localhost:1313/> in your browser, and start editing your new blog post.
 
+_**Note**: Blog posts are only displayed (at their own URLs and in the index) once the date listed in their YAML front matter has arrived. This means it's not possible to preview a post set to a future date._ 
+
 **Build the production site**
 
 ```console
@@ -75,7 +77,7 @@ $ cp 66-london-hack-week-report.md 67-incredible-adventures.md
 
 Now edit the metadata at the top of the file
 
-- `date` - the "_published at_" date, shown on the [blog index page](https://blog.ipfs.io) please update at posting time to reflect current date - **required**
+- `date` - the "_published at_" date, shown on the [blog index page](https://blog.ipfs.io) please update at posting time to reflect current date (if you postdate a post in advance of publication, it will not appear when you preview the site; only posts with current and past dates are displayed) - **required**
 - `author` - used to give you credit for your words - **required**
 - `title` - used as the `h1` on the post page, and the name of the post on the index page. **required**
 - `tags` - don't appear to be used right now, but set them anyone, as we'll want to add a "see more posts like this one" feature one day.


### PR DESCRIPTION
Clarify in the readme that setting a post's date for the future will cause it to not be displayed and prevent previewing your work. 