### PR TITLE
Updates header and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The first time you run it, it will install all the dependencies ✨, Then it wil
 
 Run it and open <http://localhost:1313/> in your browser, and start editing your new blog post.
 
-_**Note**: Blog posts are only displayed (at their own URLs and in the index) once the date listed in their YAML front matter has arrived. This means it's not possible to preview a post on localhost that is set to a future publication date._ 
+_**Note**: Blog posts are only displayed (at their own URLs and in the index) once the date listed in their YAML front matter has arrived. This means it's not possible to preview a post on localhost that is set to a future publication date._
 
 **Build the production site**
 

--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,6 @@ enableMissingTranslationPlaceholders = false
   github = "https://github.com/ipfs/blog"
   social = [ { title = "Twitter", link = "https://twitter.com/IPFSbot" },
     { title = "Facebook", link = "https://www.facebook.com/sharer/sharer.php?u=https://ipfs.io" },
-    { title = "Google", link = "https://plus.google.com/108638684245894749879" },
     { title = "YouTube", link = "https://www.youtube.com/channel/UCdjsUXJ3QawK4O5L1kqqsew" } ]
 
 [outputs]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,20 +12,37 @@
         <div class="grid-flex-cell">
           <ul class="sitemap list-unstyled">
             <li class="sitemap-head">IPFS</li>
+            <li><a href="https://ipfs.io/#install">Install</a></li>
             <li><a href="https://github.com/ipfs/ipfs">GitHub</a></li>
-            <li><a href="https://docs.ipfs.io/introduction/install/">Install</a></li>
-            <li><a href="https://ipfs.io/media">Media</a></li>
             <li><a href="https://docs.ipfs.io/">Docs</a></li>
-            <li><a href="https://docs.ipfs.io/#community">Community</a></li>
-            <li><a href="/">Blog</a></li>
+            <li><a href="https://docs.ipfs.io/community/">Community</a></li>
+            <li><a href="https://discuss.ipfs.io">Forum</a></li>
+            <li><a href="https://awesome.ipfs.io/">Awesome IPFS</a></li>
+            <li><a href="https://cluster.ipfs.io/">IPFS Cluster</a></li>
+            <li><a href="https://ipfs.io/team">Team</a></li>
+            <li><a href="https://ipfs.io/media">Media</a></li>
+            <li><a href="//blog.ipfs.io/">Blog</a></li>
             <li><a href="https://ipfs.io/legal/">Legal</a></li>
           </ul>
         </div>
         <div class="grid-flex-cell">
           <ul class="sitemap list-unstyled">
+            <li class="sitemap-head">ProtoSchool</li>
+            <li><a href="https://proto.school/#/tutorials">Tutorials</a></li>
+            <li><a href="https://proto.school/#/chapters">Chapters</a></li>
+          </ul>
+        </div>
+        <div class="grid-flex-cell">
+          <ul class="sitemap list-unstyled">
             <li class="sitemap-head">Filecoin</li>
-            <li><a href="http://filecoin.io/">About</a></li>
-            <li><a href="http://filecoin.io/filecoin.pdf">Paper</a></li>
+            <li><a href="https://filecoin.io/">About</a></li>
+            <li><a href="https://filecoin.io/faqs/">FAQ</a></li>
+          </ul>
+          <ul class="sitemap list-unstyled">
+            <li class="sitemap-head" style="padding-top: 30px;">Other Projects</li>
+            <li><a href="https://libp2p.io/">libp2p</a></li>
+            <li><a href="https://ipld.io/">IPLD</a></li>
+            <li><a href="https://multiformats.io/">Multiformats</a></li>
           </ul>
         </div>
       </div>
@@ -37,6 +54,6 @@
         </ul>
       </div>
     </div>
-    <p class="footer-copyright center">© Protocol Labs | Except as <a href="https://protocol.ai/legal/">noted</a>, content licensed <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY 3.0.</a></p>
+    <div class="footer-copyright center"><center>© Protocol Labs | Except as <a href="https://protocol.ai/legal/">noted</a>, content licensed <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY 3.0.</a></center></div>
   </div>
 </footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,13 +7,12 @@
       <input id="menu-toggle" type="checkbox" class="menu-toggle">
       <label for="menu-toggle">Menu</label>
       <ul class="list-unstyled list-inline cf">
-        <li><a href="https://ipfs.io/">About</a></li>
-        <li><a href="https://ipfs.io/#implementations">Implementations</a></li>
-        <li><a href="https://docs.ipfs.io/guides/guides/install/">Install</a></li>
+        <li><a href="https://ipfs.io/#why">About</a></li>
+        <li><a href="https://ipfs.io/#install">Install</a></li>
         <li><a href="https://docs.ipfs.io/">Docs</a></li>
         <li><a href="https://ipfs.io/team">Team</a></li>
-        <li><a href="https://ipfs.io/media">Media</a></li>
         <li><a href="{{ "/" | absURL }}" class="current-item">Blog</a></li>
+        <li><a href="http://discuss.ipfs.io/">Forum</a></li>
       </ul>
     </nav>
     <div class="hero hero-subdoc"></div>


### PR DESCRIPTION
Updates header and footer to consistency with https://github.com/ipfs/website/pull/348
- Footer was out of date for a while, this removes Google Plus link and adds ProtoSchool and related projects menus
- Header now matches rest of website's header (or at least once website/pull/348 is merged); combines "implementations" and "install" items into one easier-to-use area of guidance on main website

This completes the work laid out under issue https://github.com/ipfs/website/issues/293