### PR TITLE
fix: zh-cn links for IPFS Weekly

### DIFF
--- a/content-i18n/zh-cn/post/weekly-63.md
+++ b/content-i18n/zh-cn/post/weekly-63.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-15
-url: ipfs-weekly-63
+url: zh-cn/ipfs-weekly-63
 translationKey: ipfs-weekly-63
 tags: weekly
 title: 2019 第三季度 IPFS 回顾 🎉

--- a/content-i18n/zh-cn/post/weekly-69.md
+++ b/content-i18n/zh-cn/post/weekly-69.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-26
-url: weekly-69
+url: zh-cn/weekly-69
 translationKey: ipfs-weekly-69
 tags: weekly
 title: IPFS 周报-68

--- a/content-i18n/zh-cn/post/weekly-70.md
+++ b/content-i18n/zh-cn/post/weekly-70.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-03
-url: weekly-70
+url: zh-cn/weekly-70
 translationKey: ipfs-weekly-70
 tags: weekly
 title: IPFS 周报-70


### PR DESCRIPTION
This PR fixes english version of IPFS Weekly 63, 69 and 70
Context: some URLs of Chinese versions of blogposts were not prefixed  by `zh-cn/` which made it impossible to load English versions (both links opened Chinese). 

@moyid @renrutnnej  for future reference, make sure translated version has URL prefixed with language code:

```diff
---
date: 2019-12-03
- url: weekly-70
+ url: zh-cn/weekly-70
```
