### PR TITLE
Update 076-ipfs-docs-beta.md

### DIFF
--- a/content/post/076-ipfs-docs-beta.md
+++ b/content/post/076-ipfs-docs-beta.md
@@ -7,11 +7,11 @@ author: Jessica Schilling
 
 **We’re excited to announce [the new IPFS documentation site is live in beta](https://docs-beta.ipfs.io/)!** The doors are open, and just like any housewarming, you’re cordially invited to stop by, have a look around, and let us know what you think.
 
-<a href="https://docs-beta.ipfs.io/" target="_blank"><img src="/static/076-ipfs-docs-beta/img/docs-beta-screenshot.png" alt="Screenshot of docs beta"></a>
+<a href="https://docs-beta.ipfs.io/" target="_blank"><img src="/076-ipfs-docs-beta/img/docs-beta-screenshot.png" alt="Screenshot of docs beta"></a>
 <br/>
 *New year, new look.*
 
-![Mind map of docs beta nav](/static/076-ipfs-docs-beta/img/docs-beta-site-mindmap.png)
+![Mind map of docs beta nav](/076-ipfs-docs-beta/img/docs-beta-site-mindmap.png)
 <br/>
 *Here’s a mind map of how the docs beta’s navigation works.*
 


### PR DESCRIPTION
Paths don't resolve for the images in the docs beta blog post.