### PR TITLE
feat: add a nightly ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
           context: ipfs-dns-deploy
           requires:
             - build
-  # deploy the blog evey day at 00:00 UTC, to allow scheduled posting.
+  # deploy the blog every day at 00:00 UTC, to allow scheduled posting.
   nightly:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,3 +46,18 @@ workflows:
           context: ipfs-dns-deploy
           requires:
             - build
+  # deploy the blog evey day at 00:00 UTC, to allow scheduled posting.
+  nightly:
+    jobs:
+      - build
+      - deploy:
+          context: ipfs-dns-deploy
+          requires:
+            - build
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
Hugo allows posts to be published in the future, and they will only appear when that date arrives. Adding a nightly build allows us to use that feature...

See: https://circleci.com/docs/2.0/configuration-reference/#triggers

Fixes #365

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>