### PR TITLE
fix: redirect to canonical link when loaded from ipfs.io/blog

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -48,6 +48,7 @@
 <link rel="shortcut icon" href="{{ "/img/ipfs-logo-256-ice.png" | absURL  }}">
 <link rel="alternate feed" href="{{ "/index.xml" | absURL }}" type="application/rss+xml"  title="IPFS Blog" />
 
+<script src="/js/main.js"></script>
 <script src="/asciinema/asciinema-player.js"></script>
 <script src="/highlight/highlight.js"></script>
 <script>hljs.initHighlightingOnLoad()</script>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,4 @@
+// Fix ipfs.io/blog/* links loaded via DNSLink: https://github.com/ipfs/blog/issues/360
+if (window.location.hostname === 'ipfs.io' && window.location.pathname.startsWith('/blog')) {
+  window.location.replace(window.location.href.replace('//ipfs.io/blog', '//blog.ipfs.io'))
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,4 @@
 // Fix ipfs.io/blog/* links loaded via DNSLink: https://github.com/ipfs/blog/issues/360
-if (window.location.hostname === 'ipfs.io' && window.location.pathname.startsWith('/blog')) {
+if (window.location.hostname === 'ipfs.io' && window.location.pathname.indexOf('/blog') === 0) {
   window.location.replace(window.location.href.replace('//ipfs.io/blog', '//blog.ipfs.io'))
 }


### PR DESCRIPTION
This closes https://github.com/ipfs/blog/issues/360 by detecting page loads from `ipfs.io/blog` and replacing them with `blog.ipfs.io`.
This ensures canonical link is always present when loaded via DNSLink.

Remaining fix will land in ipfs-companion.



