### PR TITLE
fix: use blog.ipfs.io in new posts at discuss.ipfs.io

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -22,8 +22,14 @@
           <h2 id="comments">Comments</h2>
           <div id='discourse-comments'></div>
           <script type="text/javascript">
+            // posts before 2020-03-01 (unix 1583020800) used ipfs.io/blog
             DiscourseEmbed = { discourseUrl: 'https://discuss.ipfs.io/',
-              discourseEmbedUrl: 'https://ipfs.io/blog/{{ .URL }}' };
+              {{ if lt .Date.Unix 1583020800 }}
+                discourseEmbedUrl: 'https://ipfs.io/blog/{{ .URL }}'
+              {{ else }}
+                discourseEmbedUrl: 'https://blog.ipfs.io/{{ .URL }}'
+              {{ end }}
+            };
               if (window.location.hostname === 'blog.ipfs.io') {
                 (function() {
                   var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;


### PR DESCRIPTION
This PR implements the idea from https://github.com/ipfs/blog/issues/360#issuecomment-585851942

Idea is simple:
Discussion threads created at discuss.ipfs.io for blog posts with dates after 2020-03-01 would use `blog.ipfs.io` instead of `ipfs.io/blog`. 

This would close  #360 

cc @olizilla  for sanity check ;-)

## TODO before merge

- [x]  Visit `Admin > Customize > Embedding` on our Discourse install and ensure the  `/` (root) on `blog.ipfs.io` will match `Path Whitelist` entries
