### PR TITLE
Create Rust IPFS Blog Post

### DIFF
--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -57,7 +57,7 @@ To learn more about the effort, please visit the following links:
 
 ## You can help!
 
-Although Equilibrium is the main grantee, community involvment is encouraged and welcomed. If you
+Community participation in making Rust-IPFS a reality is encouraged and welcomed! If you
 want to pitch in, here are a few ways:
 
 1. Star and watch the [GitHub repo](https://github.com/ipfs-rust/rust-ipfs)

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -25,6 +25,11 @@ C++. An IPFS implementation written in Rust only makes sense. Additionally, the 
 2. Portability of certain subsets of the IPFS stack into WebAssembly
 3. Usage of IPFS functionality and APIs via native Rust function calls via inclusion as a Rust crate.
 
+Given that, it's no surprise that Rust-IPFS was also one of the [IPFS 2020 Theme Proposals](https://github.com/ipfs/roadmap/issues/54) suggested in our community-driven [IPFS 2020 Roadmapping Process](https://github.com/ipfs/roadmap/blob/master/2020-IPFS-Project-Planning.md) - and that the community quickly rose to the challenge. Equilibrium, an active participant in many dweb infrastructure projects, stepped up to take on core implementation and stewardship of this new language implementation, with support through the [new IPFS DevGrants program](https://github.com/ipfs/devgrants) to provide coordination and maintainership for passionate developers in the wider Rust community. 
+
+With both community demand and active participation, the time was ripe for the Rust-IPFS effort to be revitalized and reborn!
+
+
 ## Leveraging Community Efforts
 
 The IPFS community is a talented group of people with an impressive array of high quality work in the Rust space already. There's the aforementioned

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -33,11 +33,7 @@ With both community demand and active participation, the time was ripe for the R
 ## Leveraging Community Efforts
 
 The IPFS community is a talented group of people with an impressive array of high quality work in the Rust space already. There's the aforementioned
-[rust-libp2p](https://github.com/libp2p/rust-libp2p), which is already used by the likes of
-Polkadot, Substrate, and Lighthouse. We have ferrismtg's
-[rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api) which is aleady doing wonders in
-providing a bridge from the Rust world. Finally, we have David Craven's
-[rust-ipfs](https://github.com/ipfs-rust/rust-ipfs), which is the foundational work behind this latest endeavor.
+[rust-libp2p](https://github.com/libp2p/rust-libp2p), which is already used by the likes of Polkadot, Substrate, and Lighthouse; there's ferrismtg's [rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api) which is already doing wonders in providing a bridge from the Rust world; and of course [David Craven](https://github.com/dvc94ch)'s [rust-ipfs](https://github.com/ipfs-rust/rust-ipfs), which is the foundational work behind this latest endeavor.
 
 Instead of forking and/or starting fresh, this project aims to support and build on the impressive amount of progress that's already been made, helping carry the torch across the finish line while _incorporating_ and _including_ the community of passionate Rust contributors in the process.
 the finish line, _incorporating_ and _including_ the community into its efforts and not forking

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -34,7 +34,7 @@ Polkadot, Substrate, and Lighthouse. We have ferrismtg's
 providing a bridge from the Rust world. Finally, we have David Craven's
 [rust-ipfs](https://github.com/ipfs-rust/rust-ipfs), which is the foundational work behind this latest endeavor.
 
-This devgrant endeavors to take this impressive amount of community work and carry the torch across
+Instead of forking and/or starting fresh, this project aims to support and build on the impressive amount of progress that's already been made, helping carry the torch across the finish line while _incorporating_ and _including_ the community of passionate Rust contributors in the process.
 the finish line, _incorporating_ and _including_ the community into its efforts and not forking
 and/or starting fresh.
 

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -47,7 +47,7 @@ such as `ipfs dag put` and `ipfs dag get`.
 To learn more about the effort, you can:
 
 1. Visit the [ipfs-rust organization](https://github.com/orgs/ipfs-rust) on GitHub
-2. Read more about this effort on the Equilibrium Labs blog (link coming soon)
+2. Read more about this effort on the [Equilibrium Labs blog](https://medium.com/equilibriumco/rust-ipfs-our-plan-of-attack-af8358f90beb)
 
 ## You can help!
 

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -12,7 +12,7 @@ Active full time work on a Rust-IPFS implementation has commenced, building on t
 [Parity](https://www.parity.io/) in `rust-libp2p`. [Equilbrium](https://equilibrium.co) is spearheading the new community and
 implementation with support from Protocol Labs, and is looking for additional Rust devs itching
 to help build a new language implementation of the InterPlanetary File System combining the
-performance and resource utilization benefits of Rust with a keen eye on conformance to the IPFS spec.
+performance and resource utilization benefits of Rust with a keen eye on conformance to the IPFS spec. Read more on the [Equilibrium Labs blog](https://medium.com/equilibriumco/rust-ipfs-our-plan-of-attack-af8358f90beb)!
 
 ## Why Rust IPFS? Why Now?
 

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -1,24 +1,25 @@
 ---
 date: 2020-03-16
 url: 2020-03-16-announcing-rust-ipfs
-title: Announcing Rust IPFS
-author: Mark Robert Henderson and Volker Mische
+title: Announcing Rust IPFS, and a call for contributors
+author: Mark Robert Henderson and Molly Momack
 ---
 
 ![Rust IPFS Logo](https://github.com/ipfs-rust/logo/raw/master/rust-ipfs-logo-256w.png)
 
-We are excited to announce that we have awarded a devgrant to
-[Equilbrium](https://equilibrium.co) to work on the Rust implementation of IPFS. Our
-collective goal is to combine the _performance_ and resource utilization benefits of Rust, with
-a keen eye on _conformance_ to the IPFS spec.
+Calling all rustaceans, rustafarians, ferrosities, and rustlers - we’ve got an exciting update!
+Active full time work on a rust-IPFS implementation has commenced, building on the great work by
+Parity in `rust-libp2p`. [Equilbrium](https://equilibrium.co) is spearheading the new community and
+implementation with support from Protocol Labs, and is looking for additional rust devs itching
+to help build a new language implementation of the InterPlanetary File System combining the
+performance and resource utilization benefits of Rust with a keen eye on conformance to the IPFS spec.
 
 ## Why Rust IPFS? Why Now?
 
 Rust, the programming language, has enjoyed a recent spike in popularity. This is due both to its
 inclusive community, and also being a safe systems language with performance comparable to C and
 C++. An IPFS implementation written in Rust only makes sense. Additionally, the community has been
-looking for a Rust implementation [for a while now](https://github.com/ipfs/notes/issues/363),
-for a number of use cases:
+[asking for a while now](https://github.com/ipfs/notes/issues/363), for a number of use cases:
 
 1. Usage in resource-constrained systems such as Industrial Internet-of-Things (IIoT) controllers
 2. Portability of certain subsets of the IPFS stack into WebAssembly
@@ -26,12 +27,12 @@ for a number of use cases:
 
 ## Leveraging Community Efforts
 
-The IPFS community has been and remains and impressive, talented group of people who have
-astounded and impressed us with their work in the Rust space already. We have Parity's
+The IPFS community has been and remains an impressive, talented group of people who have
+astounded and impressed us with their work in the Rust space already. We have the aforementioned
 [rust-libp2p](https://github.com/libp2p/rust-libp2p), which is already used by the likes of
 Polkadot, Substrate, and Lighthouse. We have ferrismtg's
 [rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api) which is aleady doing wonders in
-providing a bridge from the Rust world. Finally we have David Craven's
+providing a bridge from the Rust world. Finally, we have David Craven's
 [rust-ipfs](https://github.com/ipfs-rust/rust-ipfs) foundations, which is the main repo this grant will build upon.
 
 This devgrant endeavors to take this impressive amount of community work carry the torch across

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -9,7 +9,7 @@ author: Mark Robert Henderson and Molly Mackinlay
 
 Calling all rustaceans, rustafarians, ferrosities, and rustlers - we’ve got an exciting update!
 Active full time work on a Rust-IPFS implementation has commenced, building on the great work by
-Parity in `rust-libp2p`. [Equilbrium](https://equilibrium.co) is spearheading the new community and
+[Parity](https://www.parity.io/) in `rust-libp2p`. [Equilbrium](https://equilibrium.co) is spearheading the new community and
 implementation with support from Protocol Labs, and is looking for additional Rust devs itching
 to help build a new language implementation of the InterPlanetary File System combining the
 performance and resource utilization benefits of Rust with a keen eye on conformance to the IPFS spec.

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-03-16
+date: 2020-03-18
 url: 2020-03-16-announcing-rust-ipfs
 title: Announcing Rust IPFS, and a call for contributors
 author: Mark Robert Henderson and Molly Mackinlay

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -2,7 +2,7 @@
 date: 2020-03-16
 url: 2020-03-16-announcing-rust-ipfs
 title: Announcing Rust IPFS, and a call for contributors
-author: Mark Robert Henderson and Molly Momack
+author: Mark Robert Henderson and Molly Mackinlay
 ---
 
 ![Rust IPFS Logo](https://github.com/ipfs-rust/logo/raw/master/rust-ipfs-logo-256w.png)
@@ -35,7 +35,7 @@ Polkadot, Substrate, and Lighthouse. We have ferrismtg's
 providing a bridge from the Rust world. Finally, we have David Craven's
 [rust-ipfs](https://github.com/ipfs-rust/rust-ipfs) foundations, which is the main repo this grant will build upon.
 
-This devgrant endeavors to take this impressive amount of community work carry the torch across
+This devgrant endeavors to take this impressive amount of community work and carry the torch across
 the finish line, _incorporating_ and _including_ the community into its efforts and not forking
 and/or starting fresh.
 

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -50,10 +50,10 @@ takes place mostly over early Q2 2020 and covers the use case of **IPLD applicat
 targeting the low-level blockstore, libp2p integration, and IPLD-related functionality
 such as `ipfs dag put` and `ipfs dag get`. 
 
-To learn more about the effort, please visit the following links:
+To learn more about the effort, you can:
 
-1. The [ipfs-rust organization](https://github.com/orgs/ipfs-rust) on GitHub
-2. The in-depth post on this effort on the Equilibrium Labs blog (link coming soon)
+1. Visit the [ipfs-rust organization](https://github.com/orgs/ipfs-rust) on GitHub
+2. Read more about this effort on the Equilibrium Labs blog (link coming soon)
 
 ## You can help!
 

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -27,8 +27,7 @@ C++. An IPFS implementation written in Rust only makes sense. Additionally, the 
 
 ## Leveraging Community Efforts
 
-The IPFS community has been and remains an impressive, talented group of people who have
-astounded and impressed us with their work in the Rust space already. We have the aforementioned
+The IPFS community is a talented group of people with an impressive array of high quality work in the Rust space already. There's the aforementioned
 [rust-libp2p](https://github.com/libp2p/rust-libp2p), which is already used by the likes of
 Polkadot, Substrate, and Lighthouse. We have ferrismtg's
 [rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api) which is aleady doing wonders in
@@ -59,4 +58,3 @@ want to pitch in, here are a few ways:
 1. Star and watch the [GitHub repo](https://github.com/ipfs-rust/rust-ipfs)
 2. Take on the development efforts associated with IPFS APIs [not covered by the grant](https://github.com/ipfs-rust/ipfs-rust-conformance/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 3. Back IPFS Rust on [OpenCollective](https://opencollective.com/ipfs-rust)
-

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -36,8 +36,6 @@ The IPFS community is a talented group of people with an impressive array of hig
 [rust-libp2p](https://github.com/libp2p/rust-libp2p), which is already used by the likes of Polkadot, Substrate, and Lighthouse; there's ferrismtg's [rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api) which is already doing wonders in providing a bridge from the Rust world; and of course [David Craven](https://github.com/dvc94ch)'s [rust-ipfs](https://github.com/ipfs-rust/rust-ipfs), which is the foundational work behind this latest endeavor.
 
 Instead of forking and/or starting fresh, this project aims to support and build on the impressive amount of progress that's already been made, helping carry the torch across the finish line while _incorporating_ and _including_ the community of passionate Rust contributors in the process.
-the finish line, _incorporating_ and _including_ the community into its efforts and not forking
-and/or starting fresh.
 
 ## What can be expected, and when?
 

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -61,5 +61,5 @@ Community participation in making Rust-IPFS a reality is encouraged and welcomed
 want to pitch in, here are a few ways:
 
 1. Star and watch the [GitHub repo](https://github.com/ipfs-rust/rust-ipfs)
-2. Take on the development efforts associated with IPFS APIs [not covered by the grant](https://github.com/ipfs-rust/ipfs-rust-conformance/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+2. Take on the development efforts associated with IPFS APIs [deemed out of scope for the initial grant milestones](https://github.com/ipfs-rust/ipfs-rust-conformance/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 3. Back IPFS Rust on [OpenCollective](https://opencollective.com/ipfs-rust)

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -45,7 +45,7 @@ and/or starting fresh.
 
 ## What can be expected, and when?
 
-At a high level, the [devgrant](https://github.com/ipfs/devgrants/tree/master/open-grants/ipfs-rust)
+As you can see in the [Rust-IPFS DevGrant Roadmap](https://github.com/ipfs/devgrants/tree/master/open-grants/ipfs-rust) implementation work
 takes place mostly over early Q2 2020 and covers the use case of **IPLD applications**,
 targeting the low-level blockstore, libp2p integration, and IPLD-related functionality
 such as `ipfs dag put` and `ipfs dag get`. 

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -62,4 +62,5 @@ want to pitch in, here are a few ways:
 
 1. Star and watch the [GitHub repo](https://github.com/ipfs-rust/rust-ipfs)
 2. Take on the development efforts associated with IPFS APIs [deemed out of scope for the initial grant milestones](https://github.com/ipfs-rust/ipfs-rust-conformance/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
-3. Back IPFS Rust on [OpenCollective](https://opencollective.com/ipfs-rust)
+3. Look for `help-wanted` issues that are marked as [needing help from the community](https://github.com/ipfs-rust/rust-ipfs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+4. Back IPFS Rust on [OpenCollective](https://opencollective.com/ipfs-rust)

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -32,7 +32,7 @@ The IPFS community is a talented group of people with an impressive array of hig
 Polkadot, Substrate, and Lighthouse. We have ferrismtg's
 [rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api) which is aleady doing wonders in
 providing a bridge from the Rust world. Finally, we have David Craven's
-[rust-ipfs](https://github.com/ipfs-rust/rust-ipfs) foundations, which is the main repo this grant will build upon.
+[rust-ipfs](https://github.com/ipfs-rust/rust-ipfs), which is the foundational work behind this latest endeavor.
 
 This devgrant endeavors to take this impressive amount of community work and carry the torch across
 the finish line, _incorporating_ and _including_ the community into its efforts and not forking

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -1,0 +1,61 @@
+---
+date: 2020-03-16
+url: 2020-03-16-announcing-rust-ipfs
+title: Announcing Rust IPFS
+author: Mark Robert Henderson and Volker Mische
+---
+
+![Rust IPFS Logo](https://github.com/ipfs-rust/logo/raw/master/rust-ipfs-logo-256w.png)
+
+We are excited to announce that we have awarded a devgrant to
+[Equilbrium](https://equilibrium.co) to work on the Rust implementation of IPFS. Our
+collective goal is to combine the _performance_ and resource utilization benefits of Rust, with
+a keen eye on _conformance_ to the IPFS spec.
+
+## Why Rust IPFS? Why Now?
+
+Rust, the programming language, has enjoyed a recent spike in popularity. This is due both to its
+inclusive community, and also being a safe systems language with performance comparable to C and
+C++. An IPFS implementation written in Rust only makes sense. Additionally, the community has been
+looking for a Rust implementation [for a while now](https://github.com/ipfs/notes/issues/363),
+for a number of use cases:
+
+1. Usage in resource-constrained systems such as Industrial Internet-of-Things (IIoT) controllers
+2. Portability of certain subsets of the IPFS stack into WebAssembly
+3. Usage of IPFS functionality and APIs via native Rust function calls via inclusion as a Rust crate.
+
+## Leveraging Community Efforts
+
+The IPFS community has been and remains and impressive, talented group of people who have
+astounded and impressed us with their work in the Rust space already. We have Parity's
+[rust-libp2p](https://github.com/libp2p/rust-libp2p), which is already used by the likes of
+Polkadot, Substrate, and Lighthouse. We have ferrismtg's
+[rust-ipfs-api](https://github.com/ferristseng/rust-ipfs-api) which is aleady doing wonders in
+providing a bridge from the Rust world. Finally we have David Craven's
+[rust-ipfs](https://github.com/ipfs-rust/rust-ipfs) foundations, which is the main repo this grant will build upon.
+
+This devgrant endeavors to take this impressive amount of community work carry the torch across
+the finish line, _incorporating_ and _including_ the community into its efforts and not forking
+and/or starting fresh.
+
+## What can be expected, and when?
+
+At a high level, the [devgrant](https://github.com/ipfs/devgrants/tree/master/open-grants/ipfs-rust)
+takes place mostly over early Q2 2020 and covers the use case of **IPLD applications**,
+targeting the low-level blockstore, libp2p integration, and IPLD-related functionality
+such as `ipfs dag put` and `ipfs dag get`. 
+
+To learn more about the effort, please visit the following links:
+
+1. The [ipfs-rust organization](https://github.com/orgs/ipfs-rust) on GitHub
+2. The in-depth post on this effort on the Equilibrium Labs blog (link coming soon)
+
+## You can help!
+
+Although Equilibrium is the main grantee, community involvment is encouraged and welcomed. If you
+want to pitch in, here are a few ways:
+
+1. Star and watch the [GitHub repo](https://github.com/ipfs-rust/rust-ipfs)
+2. Take on the development efforts associated with IPFS APIs [not covered by the grant](https://github.com/ipfs-rust/ipfs-rust-conformance/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+3. Back IPFS Rust on [OpenCollective](https://opencollective.com/ipfs-rust)
+

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -8,9 +8,9 @@ author: Mark Robert Henderson and Molly Mackinlay
 ![Rust IPFS Logo](https://github.com/ipfs-rust/logo/raw/master/rust-ipfs-logo-256w.png)
 
 Calling all rustaceans, rustafarians, ferrosities, and rustlers - we’ve got an exciting update!
-Active full time work on a rust-IPFS implementation has commenced, building on the great work by
+Active full time work on a Rust-IPFS implementation has commenced, building on the great work by
 Parity in `rust-libp2p`. [Equilbrium](https://equilibrium.co) is spearheading the new community and
-implementation with support from Protocol Labs, and is looking for additional rust devs itching
+implementation with support from Protocol Labs, and is looking for additional Rust devs itching
 to help build a new language implementation of the InterPlanetary File System combining the
 performance and resource utilization benefits of Rust with a keen eye on conformance to the IPFS spec.
 


### PR DESCRIPTION
Submitting a rough draft of the Rust IPFS blog post. I put an index of 085 on it and a date of March 16 to post. What I'd like to do, pending approval here, is afterward write the longer, more technical and in-depth post on the Equilibrium Blog. We can launch them together and cross-link.

@vmx and whomever else are welcome to share the byline there as well.

cc @momack2 for review