### PR TITLE
fix: ensure all posts live in directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Every post can be optionally translated by:
     ---
     date: 2018-09-25
     title: IPFS 周报-11
-    url: zh-cn/45-ipfs-weekly-11
+    url: /zh-cn/45-ipfs-weekly-11/
     translationKey: 45-ipfs-weekly-11
     ---
 	```

--- a/content-i18n/zh-cn/post/weekly-11.md
+++ b/content-i18n/zh-cn/post/weekly-11.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-09-25
-url: zh-cn/45-ipfs-weekly-11
+url: /zh-cn/45-ipfs-weekly-11/
 translationKey: 45-ipfs-weekly-11
 tags: weekly
 title: IPFS 周报-11

--- a/content-i18n/zh-cn/post/weekly-51.md
+++ b/content-i18n/zh-cn/post/weekly-51.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-23
-url: zh-cn/ipfs-weekly-51
+url: /zh-cn/ipfs-weekly-51/
 translationKey: ipfs-weekly-51
 tags: weekly
 title: IPFS 周报-51

--- a/content-i18n/zh-cn/post/weekly-52.md
+++ b/content-i18n/zh-cn/post/weekly-52.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-30
-url: zh-cn/ipfs-weekly-52
+url: /zh-cn/ipfs-weekly-52/
 translationKey: ipfs-weekly-52
 tags: weekly
 title: IPFS 周报-52

--- a/content-i18n/zh-cn/post/weekly-53.md
+++ b/content-i18n/zh-cn/post/weekly-53.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-06
-url: zh-cn/ipfs-weekly-53
+url: /zh-cn/ipfs-weekly-53/
 translationKey: ipfs-weekly-53
 tags: weekly
 title: IPFS 周报-53

--- a/content-i18n/zh-cn/post/weekly-54.md
+++ b/content-i18n/zh-cn/post/weekly-54.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-13
-url: zh-cn/ipfs-weekly-54
+url: /zh-cn/ipfs-weekly-54/
 translationKey: ipfs-weekly-54
 tags: weekly
 title: IPFS 周报-54

--- a/content-i18n/zh-cn/post/weekly-55.md
+++ b/content-i18n/zh-cn/post/weekly-55.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-20
-url: zh-cn/ipfs-weekly-55
+url: /zh-cn/ipfs-weekly-55/
 translationKey: ipfs-weekly-55
 tags: weekly
 title: IPFS 周报-55

--- a/content-i18n/zh-cn/post/weekly-56.md
+++ b/content-i18n/zh-cn/post/weekly-56.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-27
-url: zh-cn/ipfs-weekly-56
+url: /zh-cn/ipfs-weekly-56/
 translationKey: ipfs-weekly-56
 tags: weekly
 title: IPFS 周报-56

--- a/content-i18n/zh-cn/post/weekly-57.md
+++ b/content-i18n/zh-cn/post/weekly-57.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-03
-url: zh-cn/ipfs-weekly-57
+url: /zh-cn/ipfs-weekly-57/
 translationKey: ipfs-weekly-57
 tags: weekly
 title: IPFS 周报-57

--- a/content-i18n/zh-cn/post/weekly-58.md
+++ b/content-i18n/zh-cn/post/weekly-58.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-10
-url: zh-cn/ipfs-weekly-58
+url: /zh-cn/ipfs-weekly-58/
 translationKey: ipfs-weekly-58
 tags: weekly
 title: IPFS 周报-58

--- a/content-i18n/zh-cn/post/weekly-59.md
+++ b/content-i18n/zh-cn/post/weekly-59.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-17
-url: zh-cn/weekly-59
+url: /zh-cn/weekly-59/
 translationKey: ipfs-weekly-59
 tags: weekly
 title: IPFS 周报-59

--- a/content-i18n/zh-cn/post/weekly-60.md
+++ b/content-i18n/zh-cn/post/weekly-60.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-24
-url: zh-cn/weekly-60
+url: /zh-cn/weekly-60/
 translationKey: ipfs-weekly-60
 tags: weekly
 title: IPFS 周报-60

--- a/content-i18n/zh-cn/post/weekly-61.md
+++ b/content-i18n/zh-cn/post/weekly-61.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-01
-url: zh-cn/weekly-61
+url: /zh-cn/weekly-61/
 translationKey: ipfs-weekly-61
 tags: weekly
 title: IPFS 周报-61

--- a/content-i18n/zh-cn/post/weekly-62.md
+++ b/content-i18n/zh-cn/post/weekly-62.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-10
-url: zh-cn/weekly-62
+url: /zh-cn/weekly-62/
 translationKey: ipfs-weekly-62
 tags: weekly
 title: IPFS 周报-62

--- a/content-i18n/zh-cn/post/weekly-63.md
+++ b/content-i18n/zh-cn/post/weekly-63.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-15
-url: zh-cn/ipfs-weekly-63
+url: /zh-cn/ipfs-weekly-63/
 translationKey: ipfs-weekly-63
 tags: weekly
 title: 2019 第三季度 IPFS 回顾 🎉

--- a/content-i18n/zh-cn/post/weekly-64.md
+++ b/content-i18n/zh-cn/post/weekly-64.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-23
-url: zh-cn/weekly-64
+url: /zh-cn/weekly-64/
 translationKey: ipfs-weekly-64
 tags: weekly
 title: IPFS 周报-64

--- a/content-i18n/zh-cn/post/weekly-65.md
+++ b/content-i18n/zh-cn/post/weekly-65.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-29
-url: zh-ch/weekly-65
+url: /zh-ch/weekly-65/
 translationKey: ipfs-weekly-65
 tags: weekly
 title: IPFS 周报-65

--- a/content-i18n/zh-cn/post/weekly-66.md
+++ b/content-i18n/zh-cn/post/weekly-66.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-05
-url: zh-ch/weekly-66
+url: /zh-ch/weekly-66/
 translationKey: ipfs-weekly-66
 tags: weekly
 title: IPFS 周报-66

--- a/content-i18n/zh-cn/post/weekly-67.md
+++ b/content-i18n/zh-cn/post/weekly-67.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-12
-url: zh-ch/weekly-67
+url: /zh-ch/weekly-67/
 translationKey: ipfs-weekly-67
 tags: weekly
 title: IPFS 周报-67

--- a/content-i18n/zh-cn/post/weekly-68.md
+++ b/content-i18n/zh-cn/post/weekly-68.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-19
-url: zh-ch/weekly-68
+url: /zh-ch/weekly-68/
 translationKey: ipfs-weekly-68
 tags: weekly
 title: IPFS 周报-68

--- a/content-i18n/zh-cn/post/weekly-69.md
+++ b/content-i18n/zh-cn/post/weekly-69.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-26
-url: zh-cn/weekly-69
+url: /zh-cn/weekly-69/
 translationKey: ipfs-weekly-69
 tags: weekly
 title: IPFS 周报-69

--- a/content-i18n/zh-cn/post/weekly-70.md
+++ b/content-i18n/zh-cn/post/weekly-70.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-03
-url: zh-cn/weekly-70
+url: /zh-cn/weekly-70/
 translationKey: ipfs-weekly-70
 tags: weekly
 title: IPFS 周报-70

--- a/content-i18n/zh-cn/post/weekly-71.md
+++ b/content-i18n/zh-cn/post/weekly-71.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-10
-url: zh-cn/weekly-71
+url: /zh-cn/weekly-71/
 translationKey: ipfs-weekly-71
 tags: weekly
 title: IPFS 周报-71

--- a/content-i18n/zh-cn/post/weekly-72.md
+++ b/content-i18n/zh-cn/post/weekly-72.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-17
-url: zh-cn/weekly-72
+url: /zh-cn/weekly-72/
 translationKey: ipfs-weekly-72
 tags: weekly
 title: IPFS 回顾 2019 年第4季度 🎉

--- a/content/post/000-hello-worlds.md
+++ b/content/post/000-hello-worlds.md
@@ -1,6 +1,6 @@
 ---
 date: 2015-05-05
-url: 0-hello-worlds
+url: /0-hello-worlds/
 title: Hello Worlds
 author: Juan Benet
 ---

--- a/content/post/001-run-ipfs-on-docker.md
+++ b/content/post/001-run-ipfs-on-docker.md
@@ -1,6 +1,6 @@
 ---
 date: 2015-07-11
-url: 1-run-ipfs-on-docker
+url: /1-run-ipfs-on-docker/
 title: Run IPFS in a Docker container
 author: Kyle Drake
 ---

--- a/content/post/002-ipscend.md
+++ b/content/post/002-ipscend.md
@@ -1,6 +1,6 @@
 ---
 date: 2015-11-27
-url: 3-ipscend
+url: /3-ipscend/
 tags: codec
 title: ipscend - Publish static web content to IPFS
 author: David Dias

--- a/content/post/003-registry-mirror.md
+++ b/content/post/003-registry-mirror.md
@@ -1,6 +1,6 @@
 ---
 date: 2015-12-08
-url: 8-registry-mirror
+url: /8-registry-mirror/
 tags: modules
 title: Stellar Module Management - Install your Node.js modules using IPFS
 author: David Dias

--- a/content/post/004-v04x-migration.md
+++ b/content/post/004-v04x-migration.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-02-12
-url: 9-v04x-migration
+url: /9-v04x-migration/
 tags: gateway, bootstrap, infrastructure
 title: Migrating ipfs.io from go-ipfs 0.3.x to 0.4.0
 author: Lars Gierth

--- a/content/post/005-ipfs-0-4-0-released.md
+++ b/content/post/005-ipfs-0-4-0-released.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-04-07
-url: 14-ipfs-0-4-0-released
+url: /14-ipfs-0-4-0-released/
 tags: modules
 title: go-ipfs 0.4.0 has been released
 author: Kyle Drake and @whyrusleeping

--- a/content/post/006-distributions.md
+++ b/content/post/006-distributions.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-06-01
-url: 17-distributions
+url: /17-distributions/
 tags: dist, distributions
 title: IPFS distributions
 author: Richard Littauer

--- a/content/post/007-v03x-shutdown.md
+++ b/content/post/007-v03x-shutdown.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-07-09
-url: 18-v03x-shutdown
+url: /18-v03x-shutdown/
 tags: operations, v03x, gateway, bootstrap
 title: go-ipfs 0.3.x network shutdown on July 14th
 author: Lars Gierth

--- a/content/post/008-ipfs-0-4-3-released.md
+++ b/content/post/008-ipfs-0-4-3-released.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-09-20
-url: 19-ipfs-0-4-3-released
+url: /19-ipfs-0-4-3-released/
 tags: modules
 title: go-ipfs 0.4.3 has been released
 author: Lars Gierth

--- a/content/post/009-q3-review.md
+++ b/content/post/009-q3-review.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-09-27
-url: 20-q3-review
+url: /20-q3-review/
 title: Join us for the Q3 Roadmap review calls
 author: Richard littauer
 ---

--- a/content/post/010-go-ipfs-0-4-4-released.md
+++ b/content/post/010-go-ipfs-0-4-4-released.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-10-11
-url: 21-go-ipfs-0-4-4-released
+url: /21-go-ipfs-0-4-4-released/
 title: go-ipfs 0.4.4 has been released
 author: whyrusleeping & Lars Gierth
 ---

--- a/content/post/011-run-ipfs-on-a-vps.md
+++ b/content/post/011-run-ipfs-on-a-vps.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-11-14
-url: 22-run-ipfs-on-a-vps
+url: /22-run-ipfs-on-a-vps/
 title: Run IPFS latest on a VPS
 author: Richard Littauer
 ---

--- a/content/post/012-js-ipfs-0-23.md
+++ b/content/post/012-js-ipfs-0-23.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-03-24
-url: 23-js-ipfs-0-23
+url: /23-js-ipfs-0-23/
 title: js-ipfs 0.23.0 released
 author: David Dias & Victor Bjelkholm
 header_image: js-ipfs-placeholder.png

--- a/content/post/013-uncensorable-wikipedia.md
+++ b/content/post/013-uncensorable-wikipedia.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-05-04
-url: 24-uncensorable-wikipedia
+url: /24-uncensorable-wikipedia/
 title: Uncensorable Wikipedia on IPFS
 author: The IPFS Team
 ---

--- a/content/post/014-pubsub.md
+++ b/content/post/014-pubsub.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-05-17
-url: 25-pubsub
+url: /25-pubsub/
 title: Take a look at pubsub on IPFS
 author: Jeromy Johnson
 ---

--- a/content/post/015-js-ipfs-0-24.md
+++ b/content/post/015-js-ipfs-0-24.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-05-25
-url: 26-js-ipfs-0-24
+url: /26-js-ipfs-0-24/
 title: js-ipfs 0.24.0 released
 author: David Dias
 header_image: js-ipfs-placeholder.png

--- a/content/post/016-go-ipfs-0-4-10.md
+++ b/content/post/016-go-ipfs-0-4-10.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-06-28
-url: 27-go-ipfs-0-4-10
+url: /27-go-ipfs-0-4-10/
 title: go-ipfs 0.4.10 released
 author: Jeromy Johnson
 ---

--- a/content/post/017-js-ipfs-0.25.md
+++ b/content/post/017-js-ipfs-0.25.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-07-12
-url: 28-js-ipfs-0-25
+url: /28-js-ipfs-0-25/
 title: js-ipfs 0.25.0 released
 author: David Dias
 header_image: js-ipfs-placeholder.png

--- a/content/post/018-js-ipfs-pubsub.md
+++ b/content/post/018-js-ipfs-pubsub.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-07-29
-url: 29-js-ipfs-pubsub
+url: /29-js-ipfs-pubsub/
 title: Distributed pubsub primitives for js-ipfs in the Browser
 author: Pedro Teixeira
 ---

--- a/content/post/019-js-ipfs-crdts.md
+++ b/content/post/019-js-ipfs-crdts.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-08-01
-url: 30-js-ipfs-crdts
+url: /30-js-ipfs-crdts/
 title: Decentralized Real-Time Collaborative Documents - Conflict-free editing in the browser using js-ipfs and CRDTs
 author: Pedro Teixeira
 ---

--- a/content/post/020-js-ipfs-0.26.md
+++ b/content/post/020-js-ipfs-0.26.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-09-13
-url: 30-js-ipfs-0-26
+url: /30-js-ipfs-0-26/
 title: js-ipfs 0.26.0 released
 author: David Dias
 header_image: js-ipfs-placeholder.png

--- a/content/post/021-js-ipfs-0.27.md
+++ b/content/post/021-js-ipfs-0.27.md
@@ -1,6 +1,6 @@
 ---
 date: 2017-12-02
-url: 32-js-ipfs-0-27
+url: /32-js-ipfs-0-27/
 title: js-ipfs 0.27.0 released
 author: David Dias
 header_image: js-ipfs-placeholder.png

--- a/content/post/022-js-ipfs-0.28.md
+++ b/content/post/022-js-ipfs-0.28.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-03-16
-url: 33-js-ipfs-0-28
+url: /33-js-ipfs-0-28/
 title: js-ipfs 0.28.0 released
 author: David Dias
 header_image: js-ipfs-placeholder.png

--- a/content/post/023-go-ipfs-0.4.14.md
+++ b/content/post/023-go-ipfs-0.4.14.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-03-26
-url: 34-go-ipfs-0.4.14
+url: /34-go-ipfs-0.4.14/
 title: go-ipfs 0.4.14 released
 author: whyrusleeping & victorbjelkholm
 ---

--- a/content/post/024-ipfs-companion-2.2.0.md
+++ b/content/post/024-ipfs-companion-2.2.0.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-04-10
-url: 35-ipfs-companion-2-2-0
+url: /35-ipfs-companion-2-2-0/
 title: IPFS Companion 2.2.0 brings window.ipfs to your Browser
 author: lidel
 ---

--- a/content/post/025-a-look-at-windows.md
+++ b/content/post/025-a-look-at-windows.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-04-23
-url: 36-a-look-at-windows
+url: /36-a-look-at-windows/
 title: A look at go-ipfs on Windows
 author: Dominic Della Valle
 ---

--- a/content/post/026-ipfs-conf-dev-meetings-and-user-registry.md
+++ b/content/post/026-ipfs-conf-dev-meetings-and-user-registry.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-05-19
-url: 37-ipfs-conf-dev-meetings-and-user-registry
+url: /37-ipfs-conf-dev-meetings-and-user-registry/
 title: "Announcements: IPFS Conf,  Developer Meetings for IPFS & libp2p and a User Registry"
 author: flyingzumwalt
 ---

--- a/content/post/027-js-ipfs-0.29.md
+++ b/content/post/027-js-ipfs-0.29.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-05-29
-url: 38-js-ipfs-0-29
+url: /38-js-ipfs-0-29/
 title: js-ipfs 0.29.0 released
 author: David Dias
 header_image: js-ipfs-placeholder.png

--- a/content/post/028-go-libp2p-6.0.0.md
+++ b/content/post/028-go-libp2p-6.0.0.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-06-15
-url: 39-go-libp2p-6-0-0
+url: /39-go-libp2p-6-0-0/
 title: go-libp2p 6.0.0 released
 author: Steven Allen
 ---

--- a/content/post/029-js-ipfs-0.30.md
+++ b/content/post/029-js-ipfs-0.30.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-07-09
-url: 40-js-ipfs-0-30
+url: /40-js-ipfs-0-30/
 title: js-ipfs 0.30.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/030-js-libp2p-0.23.md
+++ b/content/post/030-js-libp2p-0.23.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-07-27
-url: 41-js-libp2p-0-23
+url: /41-js-libp2p-0-23/
 title: js-libp2p 0.23.0 released
 author: David Dias
 ---

--- a/content/post/031-js-ipfs-0.31.md
+++ b/content/post/031-js-ipfs-0.31.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-07-29
-url: 42-js-ipfs-0-31
+url: /42-js-ipfs-0-31/
 title: js-ipfs 0.31.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/032-js-ipfs-0.32.md
+++ b/content/post/032-js-ipfs-0.32.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-09-11
-url: 43-js-ipfs-0-32
+url: /43-js-ipfs-0-32/
 title: js-ipfs 0.32.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/033-ipld-explorer-cli-0.14.md
+++ b/content/post/033-ipld-explorer-cli-0.14.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-09-12
-url: 44-ipld-explorer-cli-0-14
+url: /44-ipld-explorer-cli-0-14/
 title: ipld-explorer-cli 0.14 released
 author: Alan Shaw
 ---

--- a/content/post/034-js-ipfs-0.33.md
+++ b/content/post/034-js-ipfs-0.33.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11-01
-url: 51-js-ipfs-0-33
+url: /51-js-ipfs-0-33/
 title: js-ipfs 0.33.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/035-go-ipfs-0-4-18.md
+++ b/content/post/035-go-ipfs-0-4-18.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11-07
-url: 53-go-ipfs-0-4-18
+url: /53-go-ipfs-0-4-18/
 title: go-ipfs 0.4.18 released
 author: Steven Allen and Erik Ingenito
 ---

--- a/content/post/036-js-libp2p-0.24.md
+++ b/content/post/036-js-libp2p-0.24.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11-16
-url: 55-js-libp2p-0-24
+url: /55-js-libp2p-0-24/
 title: js-libp2p 0.24.0 released
 author: Jacob Heun
 ---

--- a/content/post/037-http-client-rename.md
+++ b/content/post/037-http-client-rename.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-12-03
-url: 58-http-client-rename
+url: /58-http-client-rename/
 title: The HTTP client libraries are being renamed!
 author: Alan Shaw
 ---

--- a/content/post/038-js-ipfs-0.34.md
+++ b/content/post/038-js-ipfs-0.34.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-01-17
-url: 64-js-ipfs-0-34
+url: /64-js-ipfs-0-34/
 title: js-ipfs 0.34.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/039-london-hack-week-report.md
+++ b/content/post/039-london-hack-week-report.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-01-24
-url: 65-london-hack-week-report
+url: /65-london-hack-week-report/
 tags: hack week
 title: 2018 Q4 London Hack Week Summary
 author: David Dias

--- a/content/post/040-crdt-research-meetup.md
+++ b/content/post/040-crdt-research-meetup.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-03-22
-url: 67-crdt-research-meetup
+url: /67-crdt-research-meetup/
 tags: crdt research meetup videos ipfs
 title: 2018 CRDT Research Meetup - Lisbon
 author: Pedro Teixeira

--- a/content/post/041-ann-ipfs-camp.md
+++ b/content/post/041-ann-ipfs-camp.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-02-28
-url: 72-ann-ipfs-camp
+url: /72-ann-ipfs-camp/
 tags: event, camp, community
 title: Announcing, the 1st ever 🌌 IPFS Camp, Jun 27-30 🏕
 author: David Dias, Angie Maguire, Chris Waring and Jamie Nicholson

--- a/content/post/042-lisbon-hack-week.md
+++ b/content/post/042-lisbon-hack-week.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-03-25
-url: 74-lisbon-hack-week
+url: /74-lisbon-hack-week/
 tags: hack week ipfs libp2p community researchers
 title: 2018 IPFS Hack Week in Lisbon
 author: André Cruz

--- a/content/post/043-ipfs-2019-roadmap.md
+++ b/content/post/043-ipfs-2019-roadmap.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-05
-url: 78-ipfs-2019-roadmap
+url: /78-ipfs-2019-roadmap/
 title: "Achievement Unlocked: The 2019 IPFS Roadmap"
 author: Molly Mackinlay
 ---

--- a/content/post/044-js-ipfs-0.35.md
+++ b/content/post/044-js-ipfs-0.35.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-12
-url: 80-js-ipfs-0-35
+url: /80-js-ipfs-0-35/
 title: js-ipfs 0.35.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/045-js-libp2p-0.25.md
+++ b/content/post/045-js-libp2p-0.25.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-12
-url: 81-js-libp2p-0-25
+url: /81-js-libp2p-0-25/
 title: js-libp2p 0.25.0 released
 author: Jacob Heun
 header_image: 045-js-libp2p-0.25.png

--- a/content/post/046-go-ipfs-0.4.20.md
+++ b/content/post/046-go-ipfs-0.4.20.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-16
-url: 83-go-ipfs-0-4-20
+url: /83-go-ipfs-0-4-20/
 title: go-ipfs 0.4.20 released
 author: Steven Allen
 ---

--- a/content/post/047-js-ipfs-0.36.md
+++ b/content/post/047-js-ipfs-0.36.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-22
-url: 89-js-ipfs-0-36
+url: /89-js-ipfs-0-36/
 title: js-ipfs 0.36.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/048-ipfs-dev-meetings-2018.md
+++ b/content/post/048-ipfs-dev-meetings-2018.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-06-07
-url: 91-ipfs-2018-dev-meetings
+url: /91-ipfs-2018-dev-meetings/
 tags: dev meetings ipfs libp2p community researchers
 title: July 2018 IPFS Developer Meetings
 author: Molly Mackinlay

--- a/content/post/049-go-ipfs-0.4.21.md
+++ b/content/post/049-go-ipfs-0.4.21.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-06-06
-url: 93-go-ipfs-0.4.21
+url: /93-go-ipfs-0.4.21/
 title: go-ipfs 0.4.21 released
 author: Molly Mackinlay
 ---

--- a/content/post/050-ipfs-camp-recap.md
+++ b/content/post/050-ipfs-camp-recap.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-08
-url: 2019-07-08-ipfs-camp-recap
+url: /2019-07-08-ipfs-camp-recap/
 tags: IPFS, IPFS Camp
 title: 2019 IPFS Camp Recap
 author: David Dias

--- a/content/post/051-ipfs-camp-content-first-batch.md
+++ b/content/post/051-ipfs-camp-content-first-batch.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-20
-url: 2019-07-22-ipfs-camp-content-first-batch
+url: /2019-07-22-ipfs-camp-content-first-batch/
 tags: IPFS, IPFS Camp
 title: 2019 IPFS Camp 1st batch of recordings are out!
 author: David Dias

--- a/content/post/051-new-ipfs-release-process.md
+++ b/content/post/051-new-ipfs-release-process.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-14
-url: 2019-08-14-ipfs-release-process
+url: /2019-08-14-ipfs-release-process/
 tags: IPFS, go-ipfs, release process, 
 title: Improving the IPFS Release Process
 author: Steven Allen, Alan Shaw, David Dias, Molly Mackinlay, Eric Ronne, Agata Krych

--- a/content/post/052-operation-task-force.md
+++ b/content/post/052-operation-task-force.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-31
-url: 2019-07-31-operation-task-force
+url: /2019-07-31-operation-task-force/
 tags: IPFS, Project
 title: IPFS Project Q3 Priorities & Working Groups
 author: Dietrich Ayala

--- a/content/post/053-js-ipfs-0.37.md
+++ b/content/post/053-js-ipfs-0.37.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-06
-url: 2019-08-06-js-ipfs-0-37
+url: /2019-08-06-js-ipfs-0-37/
 title: js-ipfs 0.37.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/054-go-ipfs-0.4.22.md
+++ b/content/post/054-go-ipfs-0.4.22.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-13
-url: 054-go-ipfs-0.4.22
+url: /054-go-ipfs-0.4.22/
 title: go-ipfs 0.4.22 released
 author: Steven Allen
 ---

--- a/content/post/054-great-calamity-circumvention-assembly-at-ipfs-camp.md
+++ b/content/post/054-great-calamity-circumvention-assembly-at-ipfs-camp.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-12
-url: 2019-08-12-great-calamity-circumvention-assembly-at-ipfs-camp
+url: /2019-08-12-great-calamity-circumvention-assembly-at-ipfs-camp/
 tags: IPFS, IPFS Camp
 title: The Great Calamity Circumvention Assembly at IPFS Camp 2019
 author: Alan Shaw

--- a/content/post/055-js-libp2p-0.26.md
+++ b/content/post/055-js-libp2p-0.26.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-07
-url: 2019-08-07-js-libp2p-0-26
+url: /2019-08-07-js-libp2p-0-26/
 title: js-libp2p 0.26.0 released
 author: Jacob Heun
 header_image: 055-js-libp2p-0.26.png

--- a/content/post/056-pubsub-in-the-browser.md
+++ b/content/post/056-pubsub-in-the-browser.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-29
-url: 2019-08-29-pubsub-in-the-browser
+url: /2019-08-29-pubsub-in-the-browser/
 title: PubSub in the browser with the JS IPFS HTTP API client
 author: Alan Shaw
 ---

--- a/content/post/057-ipfs-camp-course-videos.md
+++ b/content/post/057-ipfs-camp-course-videos.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-18
-url: 2019-09-18-ipfs-camp-course-videos
+url: /2019-09-18-ipfs-camp-course-videos/
 title: IPFS Camp course videos released 🍿
 author: Teri Chadbourne
 ---

--- a/content/post/058-ipfs-desktop-0-9.md
+++ b/content/post/058-ipfs-desktop-0-9.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-19
-url: 2019-09-19-ipfs-desktop-0-9
+url: /2019-09-19-ipfs-desktop-0-9/
 title: IPFS Desktop 0.9 released
 author: Henrique Dias
 ---

--- a/content/post/059-ipfs-camp-sci-fi-fair-videos.md
+++ b/content/post/059-ipfs-camp-sci-fi-fair-videos.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-03
-url: 2019-10-03-ipfs-camp-sci-fi-fair-videos
+url: /2019-10-03-ipfs-camp-sci-fi-fair-videos/
 title: IPFS Camp Sci-Fi videos 🧬
 author: Arkadiy Kukarkin
 ---

--- a/content/post/060-ipfs-camp-keynotes-interviews.md
+++ b/content/post/060-ipfs-camp-keynotes-interviews.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-14
-url: 2019-10-14-ipfs-camp-keynotes-interviews
+url: /2019-10-14-ipfs-camp-keynotes-interviews/
 title: IPFS Camp Keynotes and Interviews
 author: Molly Mackinlay
 header_image: 060-ipfs-camp-keynotes-interviews.png

--- a/content/post/070-js-ipfs-0-38.md
+++ b/content/post/070-js-ipfs-0-38.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-30
-url: 070-js-ipfs-0-38
+url: /070-js-ipfs-0-38/
 title: js-ipfs 0.38.0 released
 author: Alex Potsides
 header_image: js-ipfs-placeholder.png

--- a/content/post/071-ipfs-in-web-browsers.md
+++ b/content/post/071-ipfs-in-web-browsers.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-08
-url: 2019-10-08-ipfs-browsers-update
+url: /2019-10-08-ipfs-browsers-update/
 title: IPFS Browser Update
 author: Dietrich Ayala
 header_image: 071-ipfs-in-web-browsers.png

--- a/content/post/072-js-ipfs-0.39.md
+++ b/content/post/072-js-ipfs-0.39.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-24
-url: 071-js-ipfs-0-39
+url: /071-js-ipfs-0-39/
 title: js-ipfs 0.39.0 released
 author: Alex Potsides
 header_image: js-ipfs-placeholder.png

--- a/content/post/073-073-go-ipfs-as-a-library.md
+++ b/content/post/073-073-go-ipfs-as-a-library.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-29
-url: 073-go-ipfs-as-a-library
+url: /073-go-ipfs-as-a-library/
 title: A new Tutorial has been created - Learn how to use go-ipfs as a Library
 author: David Dias
 ---

--- a/content/post/074-explore-the-files-api-on-protoschool.md
+++ b/content/post/074-explore-the-files-api-on-protoschool.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-06
-url: 2019-11-06-explore-the-files-api-on-protoschool
+url: /2019-11-06-explore-the-files-api-on-protoschool/
 title: Explore the Files API on ProtoSchool
 author: Teri Chadbourne
 header_image: 074-explore-the-files-api-on-protoschool.png

--- a/content/post/075-js-ipfs-0.40.md
+++ b/content/post/075-js-ipfs-0.40.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-02
-url: 2019-12-02-js-ipfs-0-40
+url: /2019-12-02-js-ipfs-0-40/
 title: js-ipfs 0.40.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/076-ipfs-docs-beta.md
+++ b/content/post/076-ipfs-docs-beta.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-01-07
-url: 2020-01-07-ipfs-docs-beta
+url: /2020-01-07-ipfs-docs-beta/
 title: The new IPFS Docs beta is live! 📚 🆕
 author: Jessica Schilling
 header_image: 076-ipfs-docs-beta.png

--- a/content/post/077-collaborative-clusters.md
+++ b/content/post/077-collaborative-clusters.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-01-09
-url: 2020-01-09-collaborative-clusters
+url: /2020-01-09-collaborative-clusters/
 title: Announcing collaborative clusters
 author: Hector Sanjuan
 header_image: 077-collaborative-clusters.png

--- a/content/post/078-go-ipfs-0.4.23.md
+++ b/content/post/078-go-ipfs-0.4.23.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-01-30
-url: 2020-01-30-go-ipfs-0-4-23
+url: /2020-01-30-go-ipfs-0-4-23/
 title: go-ipfs 0.4.23 released
 author: Alan Shaw
 ---

--- a/content/post/079-async-await-refactor.md
+++ b/content/post/079-async-await-refactor.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-01
-url: 2020-02-01-async-await-refactor
+url: /2020-02-01-async-await-refactor/
 title: The Async Await Refactor
 author: Alan Shaw
 ---

--- a/content/post/080-big-refactors.md
+++ b/content/post/080-big-refactors.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-06
-url: 2020-02-06-big-refactors
+url: /2020-02-06-big-refactors/
 title: Big Refactors
 author: Alan Shaw
 ---

--- a/content/post/081-js-libp2p-0.27.md
+++ b/content/post/081-js-libp2p-0.27.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-07
-url: 2020-02-07-js-libp2p-0-27
+url: /2020-02-07-js-libp2p-0-27/
 title: js-libp2p 0.27 released
 author: Jacob Heun
 header_image: 081-js-libp2p-0.27.png

--- a/content/post/082-ethdenver-2020.md
+++ b/content/post/082-ethdenver-2020.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-07
-url: 2020-02-07-ethdenver-2020
+url: /2020-02-07-ethdenver-2020/
 title: Hack with us at ETHDenver
 author: Jenn Turner
 header_image: 082-ethdenver-2020.png

--- a/content/post/082-our-focus-for-2020.md
+++ b/content/post/082-our-focus-for-2020.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-10
-url: 2020-02-10-our-focus-for-2020
+url: /2020-02-10-our-focus-for-2020/
 title: IPFS Project Focus for 2020
 author: Molly Mackinlay
 header_image: 082-our-focus-for-2020.png

--- a/content/post/083-improved-bitswap-with-netflix.md
+++ b/content/post/083-improved-bitswap-with-netflix.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-14
-url: 2020-02-14-improved-bitswap-for-container-distribution
+url: /2020-02-14-improved-bitswap-for-container-distribution/
 title: New improvements to IPFS Bitswap for faster container image distribution
 author: Dirk McCormick (IPFS) and Edgar Lee (Netflix)
 header_image: 083-improved-bitswap-with-netflix.png

--- a/content/post/083-js-ipfs-0.41.md
+++ b/content/post/083-js-ipfs-0.41.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-13
-url: 2020-02-13-js-ipfs-0-41
+url: /2020-02-13-js-ipfs-0-41/
 title: js-ipfs 0.41.0 released
 author: Alan Shaw
 header_image: js-ipfs-placeholder.png

--- a/content/post/084-explore-the-anatomy-of-a-cid-on-protoschool.md
+++ b/content/post/084-explore-the-anatomy-of-a-cid-on-protoschool.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-03-04
-url: 2020-03-04-protoschool-tutorial-anatomy-of-a-cid
+url: /2020-03-04-protoschool-tutorial-anatomy-of-a-cid/
 title: Explore the anatomy of a CID in ProtoSchool’s newest tutorial
 author: José Bateira and Teri Chadbourne
 header_image: 084-explore-the-anatomy-of-a-cid-on-protoschool.png

--- a/content/post/085-announcing-rust-ipfs.md
+++ b/content/post/085-announcing-rust-ipfs.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-03-18
-url: 2020-03-18-announcing-rust-ipfs
+url: /2020-03-18-announcing-rust-ipfs/
 title: Announcing Rust IPFS, and a call for contributors
 author: Mark Robert Henderson and Molly Mackinlay
 header_image: 085-announcing-rust-ipfs.png

--- a/content/post/086-ipfs-in-opera-for-android.md
+++ b/content/post/086-ipfs-in-opera-for-android.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-03-30
-url: 2020-03-30-ipfs-in-opera-for-android
+url: /2020-03-30-ipfs-in-opera-for-android/
 tags: IPFS, Web Browsers, Opera, Android
 title: IPFS in Opera for Android
 author: Dietrich Ayala

--- a/content/post/087-ipfs-mobile-design-research.md
+++ b/content/post/087-ipfs-mobile-design-research.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-10
-url: 2020-04-10-ipfs-mobile-design-research
+url: /2020-04-10-ipfs-mobile-design-research/
 title: IPFS Mobile Design Research
 author: Jim Kosem, Dietrich Ayala
 tags: mobile-design-guidelines, Mobile, Design, Research

--- a/content/post/087-js-ipfs-0.42.md
+++ b/content/post/087-js-ipfs-0.42.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-14
-url: 2020-04-14-js-ipfs-0-42
+url: /2020-04-14-js-ipfs-0-42/
 title: js-ipfs 0.42.0 released
 header_image: js-ipfs-placeholder.png
 author: Alex Potsides

--- a/content/post/088-ipfs-grants-platform.md
+++ b/content/post/088-ipfs-grants-platform.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-20
-url: 2020-04-20-ipfs-grants-platform
+url: /2020-04-20-ipfs-grants-platform/
 title: IPFS Grants Platform
 author: Arkadiy Kukarkin, Molly Mackinlay
 header_image: 088-ipfs-grants-platform.png

--- a/content/post/089-ipfs-mobile-design-research-findings.md
+++ b/content/post/089-ipfs-mobile-design-research-findings.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-24
-url: 2020-04-24-ipfs-mobile-design-research-findings
+url: /2020-04-24-ipfs-mobile-design-research-findings/
 title: IPFS Mobile Design Research Findings
 author: Jim Kosem, Dietrich Ayala
 tags: mobile-design-guidelines, Mobile, Design, Research

--- a/content/post/090-go-ipfs-0-5-0.md
+++ b/content/post/090-go-ipfs-0-5-0.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-28
-url: 2020-04-28-go-ipfs-0-5-0
+url: /2020-04-28-go-ipfs-0-5-0/
 title: IPFS 0.5.0 is here! Our largest upgrade to IPFS yet
 author: Molly Mackinlay
 header_image: 090-go-ipfs-0-5-0.png

--- a/content/post/091-dev-exp.md
+++ b/content/post/091-dev-exp.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-05
-url: 2020-05-05-developer-experience
+url: /2020-05-05-developer-experience/
 title: Improving the IPFS Developer experience
 author: Hector Sanjuan
 tags: Developer, Experience

--- a/content/post/092-launching-testground.md
+++ b/content/post/092-launching-testground.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-06
-url: 2020-05-06-launching-testground
+url: /2020-05-06-launching-testground/
 title: Launching Testground v0.5
 author: Raul Kripalani
 header_image: 092-launching-testground.png

--- a/content/post/093-ipfs-pinning-summit-recap.md
+++ b/content/post/093-ipfs-pinning-summit-recap.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-13
-url: 2020-05-13-ipfs-pinning-summit-recap
+url: /2020-05-13-ipfs-pinning-summit-recap/
 title: IPFS Pinning Summit Recap
 author: Molly Mackinlay & Pooja Shah
 header_image: 093-ipfs-pinning-summit-recap.png

--- a/content/post/094-gossipsub-v1.1.md
+++ b/content/post/094-gossipsub-v1.1.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-20
-url: 2020-05-20-gossipsub-v1.1
+url: /2020-05-20-gossipsub-v1.1/
 title: Gossipsub v1.1 brings hardening extensions to PubSub 
 author: David Dias
 header_image: 094-gossipsub-v1.1-headerimage.jpeg

--- a/content/post/095-road-to-dht.md
+++ b/content/post/095-road-to-dht.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-19
-url: 2020-05-19-road-to-dht
+url: /2020-05-19-road-to-dht/
 title: The Road to the New DHT
 author: Adin Schmahmann
 header_image: 095-road-to-dht.png

--- a/content/post/096-js-ipfs-0.44.md
+++ b/content/post/096-js-ipfs-0.44.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-21
-url: 2020-05-21-js-ipfs-0-44
+url: /2020-05-21-js-ipfs-0-44/
 title: js-ipfs 0.44.0 released
 header_image: js-ipfs-placeholder.png
 author: Alex Potsides

--- a/content/post/meet-the-community--Alan-Shaw-IPFS.md
+++ b/content/post/meet-the-community--Alan-Shaw-IPFS.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-20
-url: meet-the-community-alan-shaw
+url: /meet-the-community-alan-shaw/
 tags: "Meet the Community"
 title: Meet the Community, Alan Shaw @ IPFS / Protocol Labs
 author: IPFS Events Team

--- a/content/post/meet-the-community--Carson-Farmer-Textile.md
+++ b/content/post/meet-the-community--Carson-Farmer-Textile.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-13
-url: meet-the-community-carson-farmer
+url: /meet-the-community-carson-farmer/
 tags: "Meet the Community"
 title: Meet the Community, Carson Farmer @ Textile
 author: IPFS Events Team

--- a/content/post/meet-the-community--Edgar-Lee-Netflix.md
+++ b/content/post/meet-the-community--Edgar-Lee-Netflix.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-06
-url: meet-the-community-edgar-lee
+url: /meet-the-community-edgar-lee/
 tags: "Meet the Community"
 title: Meet the Community, Edgar Lee @ Netflix
 author: IPFS Events Team

--- a/content/post/weekly-001.md
+++ b/content/post/weekly-001.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-01-11
-url: 4-ipfs-weekly-1
+url: /4-ipfs-weekly-1/
 tags: weekly
 title: IPFS Weekly 1
 author: Richard Littauer, Andrew Chin

--- a/content/post/weekly-002.md
+++ b/content/post/weekly-002.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-01-13
-url: 5-ipfs-weekly-2
+url: /5-ipfs-weekly-2/
 tags: weekly
 title: IPFS Weekly 2
 author: Richard Littauer, Andrew Chin

--- a/content/post/weekly-003.md
+++ b/content/post/weekly-003.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-02-01
-url: 6-ipfs-weekly-3
+url: /6-ipfs-weekly-3/
 tags: weekly
 title: IPFS Weekly 3
 author: Richard Littauer, Andrew Chin

--- a/content/post/weekly-004.md
+++ b/content/post/weekly-004.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-02-05
-url: 7-ipfs-weekly-4
+url: /7-ipfs-weekly-4/
 tags: weekly
 title: IPFS Weekly 4
 author: Richard Littauer, Andrew Chin

--- a/content/post/weekly-005.md
+++ b/content/post/weekly-005.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-03-04
-url: 10-ipfs-weekly-5
+url: /10-ipfs-weekly-5/
 tags: weekly
 title: IPFS Weekly 5
 author: Richard Littauer, Andrew Chin

--- a/content/post/weekly-006.md
+++ b/content/post/weekly-006.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-03-09
-url: 11-ipfs-weekly-6
+url: /11-ipfs-weekly-6/
 tags: weekly
 title: IPFS Weekly 6
 author: Richard Littauer, Andrew Chin

--- a/content/post/weekly-007.md
+++ b/content/post/weekly-007.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-03-17
-url: 12-ipfs-weekly-7
+url: /12-ipfs-weekly-7/
 tags: weekly
 title: IPFS Weekly 7
 author: Richard Littauer, Andrew Chin

--- a/content/post/weekly-008.md
+++ b/content/post/weekly-008.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-03-22
-url: 13-ipfs-weekly-8
+url: /13-ipfs-weekly-8/
 tags: weekly
 title: IPFS Weekly 8
 author: Richard Littauer

--- a/content/post/weekly-009.md
+++ b/content/post/weekly-009.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-04-20
-url: 15-ipfs-weekly-9
+url: /15-ipfs-weekly-9/
 tags: weekly
 title: IPFS Weekly 9
 author: Richard Littauer

--- a/content/post/weekly-010.md
+++ b/content/post/weekly-010.md
@@ -1,6 +1,6 @@
 ---
 date: 2016-05-08
-url: 16-ipfs-weekly-10
+url: /16-ipfs-weekly-10/
 tags: weekly
 title: IPFS Weekly 10
 author: Richard Littauer

--- a/content/post/weekly-011.md
+++ b/content/post/weekly-011.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-09-25
-url: 45-ipfs-weekly-11
+url: /45-ipfs-weekly-11/
 translationKey: 45-ipfs-weekly-11
 tags: weekly
 title: IPFS Weekly 11

--- a/content/post/weekly-012.md
+++ b/content/post/weekly-012.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-10-02
-url: 46-ipfs-weekly-12
+url: /46-ipfs-weekly-12/
 tags: weekly
 title: IPFS Weekly 12
 author: Jenn Turner

--- a/content/post/weekly-013.md
+++ b/content/post/weekly-013.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-10-09
-url: 47-ipfs-weekly-13
+url: /47-ipfs-weekly-13/
 tags: weekly
 title: IPFS Weekly 13
 author: Jenn Turner

--- a/content/post/weekly-014.md
+++ b/content/post/weekly-014.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-10-16
-url: 48-ipfs-weekly-14
+url: /48-ipfs-weekly-14/
 tags: weekly
 title: IPFS Weekly 14
 author: Jenn Turner

--- a/content/post/weekly-015.md
+++ b/content/post/weekly-015.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-10-23
-url: 49-ipfs-weekly-15
+url: /49-ipfs-weekly-15/
 tags: weekly
 title: IPFS Weekly 15
 author: Jenn Turner

--- a/content/post/weekly-016.md
+++ b/content/post/weekly-016.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-10-30
-url: 50-ipfs-weekly-16
+url: /50-ipfs-weekly-16/
 tags: weekly
 title: IPFS Weekly 16
 author: Jenn Turner

--- a/content/post/weekly-017.md
+++ b/content/post/weekly-017.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11-06
-url: 52-ipfs-weekly-17
+url: /52-ipfs-weekly-17/
 tags: weekly
 title: IPFS Weekly 17
 author: Jenn Turner

--- a/content/post/weekly-018.md
+++ b/content/post/weekly-018.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11-13
-url: 54-ipfs-weekly-18
+url: /54-ipfs-weekly-18/
 tags: weekly
 title: IPFS Weekly 18
 author: Jenn Turner

--- a/content/post/weekly-019.md
+++ b/content/post/weekly-019.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11-20
-url: 56-ipfs-weekly-19
+url: /56-ipfs-weekly-19/
 tags: weekly
 title: IPFS Weekly 19
 author: Jenn Turner

--- a/content/post/weekly-020.md
+++ b/content/post/weekly-020.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-11-27
-url: 57-ipfs-weekly-20
+url: /57-ipfs-weekly-20/
 tags: weekly
 title: IPFS Weekly 20
 author: Jenn Turner

--- a/content/post/weekly-021.md
+++ b/content/post/weekly-021.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-12-04
-url: 59-ipfs-weekly-21
+url: /59-ipfs-weekly-21/
 tags: weekly
 title: IPFS Weekly 21
 author: Jenn Turner

--- a/content/post/weekly-022.md
+++ b/content/post/weekly-022.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-12-11
-url: 60-ipfs-weekly-22
+url: /60-ipfs-weekly-22/
 tags: weekly
 title: IPFS Weekly 22
 author: Jenn Turner

--- a/content/post/weekly-023.md
+++ b/content/post/weekly-023.md
@@ -1,6 +1,6 @@
 ---
 date: 2018-12-18
-url: 61-ipfs-weekly-23
+url: /61-ipfs-weekly-23/
 tags: weekly
 title: IPFS Weekly 23
 author: Jenn Turner

--- a/content/post/weekly-024.md
+++ b/content/post/weekly-024.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-01-08
-url: 62-ipfs-weekly-24
+url: /62-ipfs-weekly-24/
 tags: weekly
 title: IPFS Weekly 24
 author: Jenn Turner

--- a/content/post/weekly-025.md
+++ b/content/post/weekly-025.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-01-15
-url: 63-ipfs-weekly-25
+url: /63-ipfs-weekly-25/
 tags: weekly
 title: IPFS Weekly 25
 author: Jenn Turner

--- a/content/post/weekly-026.md
+++ b/content/post/weekly-026.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-01-22
-url: 65-ipfs-weekly-26
+url: /65-ipfs-weekly-26/
 tags: weekly
 title: IPFS Weekly 26
 author: Jenn Turner

--- a/content/post/weekly-027.md
+++ b/content/post/weekly-027.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-01-29
-url: 67-ipfs-weekly-27
+url: /67-ipfs-weekly-27/
 tags: weekly
 title: IPFS Weekly 27
 author: Jenn Turner

--- a/content/post/weekly-028.md
+++ b/content/post/weekly-028.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-02-05
-url: 68-ipfs-weekly-28
+url: /68-ipfs-weekly-28/
 tags: weekly
 title: IPFS Weekly 28
 author: Jenn Turner

--- a/content/post/weekly-029.md
+++ b/content/post/weekly-029.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-02-12
-url: 69-ipfs-weekly-29
+url: /69-ipfs-weekly-29/
 tags: weekly
 title: IPFS Weekly 29
 author: Jenn Turner

--- a/content/post/weekly-030.md
+++ b/content/post/weekly-030.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-02-19
-url: 70-ipfs-weekly-30
+url: /70-ipfs-weekly-30/
 tags: weekly
 title: IPFS Weekly 30
 author: Jenn Turner

--- a/content/post/weekly-031.md
+++ b/content/post/weekly-031.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-02-26
-url: 71-ipfs-weekly-31
+url: /71-ipfs-weekly-31/
 tags: weekly
 title: IPFS Weekly 31
 author: Jenn Turner

--- a/content/post/weekly-032.md
+++ b/content/post/weekly-032.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-03-05
-url: 73-ipfs-weekly-32
+url: /73-ipfs-weekly-32/
 tags: weekly
 title: IPFS Weekly 32
 author: Jenn Turner

--- a/content/post/weekly-033.md
+++ b/content/post/weekly-033.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-03-12
-url: 74-ipfs-weekly-33
+url: /74-ipfs-weekly-33/
 tags: weekly
 title: IPFS Weekly 33
 author: Jenn Turner

--- a/content/post/weekly-034.md
+++ b/content/post/weekly-034.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-03-19
-url: 75-ipfs-weekly-34
+url: /75-ipfs-weekly-34/
 tags: weekly
 title: IPFS Weekly 34
 author: Jenn Turner

--- a/content/post/weekly-035.md
+++ b/content/post/weekly-035.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-03-26
-url: 76-ipfs-weekly-35
+url: /76-ipfs-weekly-35/
 tags: weekly
 title: IPFS Weekly 35
 author: Jenn Turner

--- a/content/post/weekly-036.md
+++ b/content/post/weekly-036.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-02
-url: 77-ipfs-weekly-36
+url: /77-ipfs-weekly-36/
 tags: weekly
 title: IPFS Weekly 36
 author: Jenn Turner

--- a/content/post/weekly-037.md
+++ b/content/post/weekly-037.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-10
-url: 79-ipfs-weekly-37
+url: /79-ipfs-weekly-37/
 tags: weekly
 title: Recapping IPFS in Q1 2019 🎉
 author: Jenn Turner

--- a/content/post/weekly-038.md
+++ b/content/post/weekly-038.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-16
-url: 82-ipfs-weekly-38
+url: /82-ipfs-weekly-38/
 tags: weekly
 title: IPFS Weekly 38
 author: Jenn Turner

--- a/content/post/weekly-039.md
+++ b/content/post/weekly-039.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-23
-url: 84-ipfs-weekly-39
+url: /84-ipfs-weekly-39/
 tags: weekly
 title: IPFS Weekly 39
 author: Jenn Turner

--- a/content/post/weekly-040.md
+++ b/content/post/weekly-040.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-04-30
-url: 85-ipfs-weekly-40
+url: /85-ipfs-weekly-40/
 tags: weekly
 title: IPFS Weekly 40
 author: Jenn Turner

--- a/content/post/weekly-041.md
+++ b/content/post/weekly-041.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-07
-url: 86-ipfs-weekly-41
+url: /86-ipfs-weekly-41/
 tags: weekly
 title: IPFS Weekly 41
 author: Jenn Turner

--- a/content/post/weekly-042.md
+++ b/content/post/weekly-042.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-14
-url: 87-ipfs-weekly-42
+url: /87-ipfs-weekly-42/
 tags: weekly
 title: IPFS Weekly 42
 author: Jenn Turner

--- a/content/post/weekly-043.md
+++ b/content/post/weekly-043.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-21
-url: 88-ipfs-weekly-43
+url: /88-ipfs-weekly-43/
 tags: weekly
 title: IPFS Weekly 43
 author: Jenn Turner

--- a/content/post/weekly-044.md
+++ b/content/post/weekly-044.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-05-28
-url: 90-ipfs-weekly-44
+url: /90-ipfs-weekly-44/
 tags: weekly
 title: IPFS Weekly 44
 author: Jenn Turner

--- a/content/post/weekly-045.md
+++ b/content/post/weekly-045.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-06-11
-url: 94-ipfs-weekly-45
+url: /94-ipfs-weekly-45/
 tags: weekly
 title: IPFS Weekly 45
 author: Jenn Turner

--- a/content/post/weekly-046.md
+++ b/content/post/weekly-046.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-06-18
-url: 95-ipfs-weekly-46
+url: /95-ipfs-weekly-46/
 tags: weekly
 title: IPFS Weekly 46
 author: Jenn Turner

--- a/content/post/weekly-047.md
+++ b/content/post/weekly-047.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-06-25
-url: 96-ipfs-weekly-47
+url: /96-ipfs-weekly-47/
 tags: weekly
 title: IPFS Weekly 47
 author: Jenn Turner

--- a/content/post/weekly-048.md
+++ b/content/post/weekly-048.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-02
-url: 97-ipfs-weekly-48
+url: /97-ipfs-weekly-48/
 tags: weekly
 title: IPFS Weekly 48
 author: Jenn Turner

--- a/content/post/weekly-049.md
+++ b/content/post/weekly-049.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-09
-url: 98-ipfs-weekly-49
+url: /98-ipfs-weekly-49/
 tags: weekly
 title: Recapping IPFS in Q2 2019 🎉
 author: Jenn Turner

--- a/content/post/weekly-050.md
+++ b/content/post/weekly-050.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-16
-url: weekly-50
+url: /weekly-50/
 tags: weekly
 title: IPFS Weekly 50
 author: Jenn Turner

--- a/content/post/weekly-051.md
+++ b/content/post/weekly-051.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-23
-url: weekly-51
+url: /weekly-51/
 translationKey: ipfs-weekly-51
 tags: weekly
 title: IPFS Weekly 51

--- a/content/post/weekly-052.md
+++ b/content/post/weekly-052.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-07-30
-url: weekly-52
+url: /weekly-52/
 translationKey: ipfs-weekly-52
 tags: weekly
 title: IPFS Weekly 52

--- a/content/post/weekly-053.md
+++ b/content/post/weekly-053.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-06
-url: weekly-53
+url: /weekly-53/
 translationKey: ipfs-weekly-53
 tags: weekly
 title: IPFS Weekly 53

--- a/content/post/weekly-054.md
+++ b/content/post/weekly-054.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-13
-url: weekly-54
+url: /weekly-54/
 translationKey: ipfs-weekly-54
 tags: weekly
 title: IPFS Weekly 54

--- a/content/post/weekly-055.md
+++ b/content/post/weekly-055.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-20
-url: weekly-55
+url: /weekly-55/
 translationKey: ipfs-weekly-55
 tags: weekly
 title: IPFS Weekly 55

--- a/content/post/weekly-056.md
+++ b/content/post/weekly-056.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-08-27
-url: weekly-56
+url: /weekly-56/
 translationKey: ipfs-weekly-56
 tags: weekly
 title: IPFS Weekly 56

--- a/content/post/weekly-057.md
+++ b/content/post/weekly-057.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-03
-url: weekly-57
+url: /weekly-57/
 translationKey: ipfs-weekly-57
 tags: weekly
 title: IPFS Weekly 57

--- a/content/post/weekly-058.md
+++ b/content/post/weekly-058.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-10
-url: weekly-58
+url: /weekly-58/
 translationKey: ipfs-weekly-58
 tags: weekly
 title: IPFS Weekly 58

--- a/content/post/weekly-059.md
+++ b/content/post/weekly-059.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-17
-url: weekly-59
+url: /weekly-59/
 translationKey: ipfs-weekly-59
 tags: weekly
 title: IPFS Weekly 59

--- a/content/post/weekly-060.md
+++ b/content/post/weekly-060.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-09-24
-url: weekly-60
+url: /weekly-60/
 translationKey: ipfs-weekly-60
 tags: weekly
 title: IPFS Weekly 60

--- a/content/post/weekly-061.md
+++ b/content/post/weekly-061.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-01
-url: weekly-61
+url: /weekly-61/
 translationKey: ipfs-weekly-61
 tags: weekly
 title: IPFS Weekly 61

--- a/content/post/weekly-062.md
+++ b/content/post/weekly-062.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-10
-url: weekly-62
+url: /weekly-62/
 translationKey: ipfs-weekly-62
 tags: weekly
 title: IPFS Weekly 62

--- a/content/post/weekly-063.md
+++ b/content/post/weekly-063.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-15
-url: weekly-63
+url: /weekly-63/
 translationKey: ipfs-weekly-63
 tags: weekly
 title: Recapping IPFS in Q3 2019 🎉

--- a/content/post/weekly-064.md
+++ b/content/post/weekly-064.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-22
-url: weekly-64
+url: /weekly-64/
 translationKey: ipfs-weekly-64
 tags: weekly
 title: IPFS Weekly 64

--- a/content/post/weekly-065.md
+++ b/content/post/weekly-065.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-29
-url: weekly-65
+url: /weekly-65/
 translationKey: ipfs-weekly-65
 tags: weekly
 title: IPFS Weekly 65

--- a/content/post/weekly-066.md
+++ b/content/post/weekly-066.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-05
-url: weekly-66
+url: /weekly-66/
 translationKey: ipfs-weekly-66
 tags: weekly
 title: IPFS Weekly 66

--- a/content/post/weekly-067.md
+++ b/content/post/weekly-067.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-12
-url: weekly-67
+url: /weekly-67/
 translationKey: ipfs-weekly-67
 tags: weekly
 title: IPFS Weekly 67

--- a/content/post/weekly-068.md
+++ b/content/post/weekly-068.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-19
-url: weekly-68
+url: /weekly-68/
 translationKey: ipfs-weekly-68
 tags: weekly
 title: IPFS Weekly 68

--- a/content/post/weekly-069.md
+++ b/content/post/weekly-069.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-11-26
-url: weekly-69
+url: /weekly-69/
 translationKey: ipfs-weekly-69
 tags: weekly
 title: IPFS Weekly 69

--- a/content/post/weekly-070.md
+++ b/content/post/weekly-070.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-03
-url: weekly-70
+url: /weekly-70/
 translationKey: ipfs-weekly-70
 tags: weekly
 title: IPFS Weekly 70

--- a/content/post/weekly-071.md
+++ b/content/post/weekly-071.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-10
-url: weekly-71
+url: /weekly-71/
 translationKey: ipfs-weekly-71
 tags: weekly
 title: IPFS Weekly 71

--- a/content/post/weekly-072.md
+++ b/content/post/weekly-072.md
@@ -1,6 +1,6 @@
 ---
 date: 2019-12-17
-url: weekly-72
+url: /weekly-72/
 translationKey: ipfs-weekly-72
 tags: weekly
 title: Recapping IPFS in Q4 2019 🎉

--- a/content/post/weekly-073.md
+++ b/content/post/weekly-073.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-01-14
-url: weekly-73
+url: /weekly-73/
 translationKey: ipfs-weekly-73
 tags: weekly
 title: IPFS Weekly 73

--- a/content/post/weekly-074.md
+++ b/content/post/weekly-074.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-01-21
-url: weekly-74
+url: /weekly-74/
 translationKey: ipfs-weekly-74
 tags: weekly
 title: IPFS Weekly 74

--- a/content/post/weekly-075.md
+++ b/content/post/weekly-075.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-01-28
-url: weekly-75
+url: /weekly-75/
 translationKey: ipfs-weekly-75
 tags: weekly
 title: IPFS Weekly 75

--- a/content/post/weekly-076.md
+++ b/content/post/weekly-076.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-04
-url: weekly-76
+url: /weekly-76/
 translationKey: ipfs-weekly-76
 tags: weekly
 title: IPFS Weekly 76

--- a/content/post/weekly-077.md
+++ b/content/post/weekly-077.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-11
-url: weekly-77
+url: /weekly-77/
 translationKey: ipfs-weekly-77
 tags: weekly
 title: IPFS Weekly 77

--- a/content/post/weekly-078.md
+++ b/content/post/weekly-078.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-18
-url: weekly-78
+url: /weekly-78/
 translationKey: ipfs-weekly-78
 tags: weekly
 title: IPFS Weekly 78

--- a/content/post/weekly-079.md
+++ b/content/post/weekly-079.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-02-25
-url: weekly-79
+url: /weekly-79/
 translationKey: ipfs-weekly-79
 tags: weekly
 title: IPFS Weekly 79

--- a/content/post/weekly-080.md
+++ b/content/post/weekly-080.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-03-03
-url: weekly-80
+url: /weekly-80/
 translationKey: ipfs-weekly-80
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-081.md
+++ b/content/post/weekly-081.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-03-10
-url: weekly-81
+url: /weekly-81/
 translationKey: ipfs-weekly-81
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-082.md
+++ b/content/post/weekly-082.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-03-24
-url: weekly-82
+url: /weekly-82/
 translationKey: ipfs-weekly-82
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-083.md
+++ b/content/post/weekly-083.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-03-31
-url: weekly-83
+url: /weekly-83/
 translationKey: ipfs-weekly-83
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-084.md
+++ b/content/post/weekly-084.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-08
-url: weekly-84
+url: /weekly-84/
 translationKey: ipfs-weekly-84
 tags: weekly
 title: IPFS Weekly Q1 2020 Recap 🎉

--- a/content/post/weekly-085.md
+++ b/content/post/weekly-085.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-14
-url: weekly-85
+url: /weekly-85/
 translationKey: ipfs-weekly-85
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-086.md
+++ b/content/post/weekly-086.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-21
-url: weekly-86
+url: /weekly-86/
 translationKey: ipfs-weekly-86
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-087.md
+++ b/content/post/weekly-087.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-04-28
-url: weekly-87
+url: /weekly-87/
 translationKey: ipfs-weekly-87
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-088.md
+++ b/content/post/weekly-088.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-05
-url: weekly-88
+url: /weekly-88/
 translationKey: ipfs-weekly-88
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-089.md
+++ b/content/post/weekly-089.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-12
-url: weekly-89
+url: /weekly-89/
 translationKey: ipfs-weekly-89
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-090.md
+++ b/content/post/weekly-090.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-20
-url: weekly-90
+url: /weekly-90/
 translationKey: ipfs-weekly-90
 tags: weekly
 header_image: weekly-newsletter.png

--- a/content/post/weekly-091.md
+++ b/content/post/weekly-091.md
@@ -1,6 +1,6 @@
 ---
 date: 2020-05-27
-url: weekly-91
+url: /weekly-91/
 translationKey: ipfs-weekly-91
 tags: weekly
 header_image: weekly-newsletter.png

--- a/drafts/templates/index.md
+++ b/drafts/templates/index.md
@@ -1,7 +1,8 @@
 ---
 # this is the final blog post's url (used in the directory)
 # should only contain: letters, numbers, dashes.
-url: final-blog-post-name
+# it should start and end with a slash
+url: /final-blog-post-name/
 
 # the date here should be set to the final publication date,
 # on the day it is published.


### PR DESCRIPTION
The URL field needs to start and end with a slash. Otherwise, if it contains a dot, hugo might interpret it as a filename with an extension.

fixes #423