### PR TITLE
docs: add blog post for go-ipfs 0.6

### DIFF
--- a/content/post/101-go-ipfs-0-6-0.md
+++ b/content/post/101-go-ipfs-0-6-0.md
@@ -11,8 +11,8 @@ tags: go-ipfs, release
 **MIGRATION:** This release contains a small config migration to enable listening on the QUIC transport in addition to the TCP transport. This migration will:
 
 * Normalize multiaddrs in the bootstrap list to use the `/p2p/Qm...` syntax for multiaddrs instead of the `/ipfs/Qm...` syntax.
-* Add QUIC addresses for the default bootstrappers, as necessary. If you've removed the default bootstrappers from your bootstrap config, the migration won't add them back.
-* Add a QUIC listener address to mirror any TCP addresses present in your config. For example, if you're listening on `/ip4/0.0.0.0/tcp/1234`, this migration will add a listen address for `/ip4/0.0.0.0/udp/1234/quic`.
+* Add QUIC addresses for the default bootstrappers, as necessary. If you’ve removed the default bootstrappers from your bootstrap config, the migration won’t add them back.
+* Add a QUIC listener address to mirror any TCP addresses present in your config. For example, if you’re listening on `/ip4/0.0.0.0/tcp/1234`, this migration will add a listen address for `/ip4/0.0.0.0/udp/1234/quic`.
 
 ## 🚂 QUIC is now enabled by default
 
@@ -20,7 +20,7 @@ This release enables the QUIC transport (draft 28) by default for both inbound a
 
 If you want to learn more about the advantages of QUIC, check out the [release notes](https://github.com/ipfs/go-ipfs/releases/tag/v0.6.0) for more information.
 
-**NOTE:** The QUIC transport included in this release is backwards incompatible with the experimental QUIC transport included in previous releases. Unfortunately, the QUIC protocol underwent some significant breaking changes and supporting multiple versions wasn't an option. In practice this degrades gracefully as go-ipfs will simply fall back on the TCP transport when dialing nodes with incompatible QUIC versions.
+**NOTE:** The QUIC transport included in this release is backwards incompatible with the experimental QUIC transport included in previous releases. Unfortunately, the QUIC protocol underwent some significant breaking changes and supporting multiple versions wasn’t an option. In practice this degrades gracefully as go-ipfs will simply fall back on the TCP transport when dialing nodes with incompatible QUIC versions.
 
 ## 🔐 Introducing the Noise Security Transport
 
@@ -28,7 +28,7 @@ This go-ipfs release introduces a new security transport: [libp2p Noise](https:/
 
 This brings us one step closer to deprecating and removing support for SECIO.
 
-While enabled by default, TLS1.3 and SECIO will still be negotiated prior to Noise. Once the network has had time to upgrade, Noise will take priority over SECIO. If you'd like to prefer Noise over other security transports, you can change its priority in the [config](https://github.com/ipfs/go-ipfs/blob/v0.6.0/docs/config.md#swarmtransportssecurity) (`Swarm.Transports.Security.Noise`).
+While enabled by default, TLS1.3 and SECIO will still be negotiated prior to Noise. Once the network has had time to upgrade, Noise will take priority over SECIO. If you’d like to prefer Noise over other security transports, you can change its priority in the [config](https://github.com/ipfs/go-ipfs/blob/v0.6.0/docs/config.md#swarmtransportssecurity) (`Swarm.Transports.Security.Noise`).
 
 ## 🚪 Gateway
 
@@ -36,15 +36,15 @@ This release brings two gateway-relevant features: custom 404 pages and base36 s
 
 ### 🚫 Custom 404 pages
 
-You can now customize `404 Not Found` error pages by including an `ipfs-404.html` file somewhere in the request path. When a requested file isn't found, go-ipfs will look for an `ipfs-404.html` in the same directory as the requested file, and in each parent directory. If found, this file will be returned (with a 404 status code) instead of the usual error message.
+You can now customize `404 Not Found` error pages by including an `ipfs-404.html` file somewhere in the request path. When a requested file isn’t found, go-ipfs will look for an `ipfs-404.html` in the same directory as the requested file, and in each parent directory. If found, this file will be returned (with a 404 status code) instead of the usual error message.
 
 ### 🗝️ Base36 Support
 
 This release adds support for a new multibase encoding: base36. Base36 is an optimally efficient case-insensitive alphanumeric encoding. Case-insensitive alphanumeric encodings are important for the subdomain gateway as domain names are case insensitive.
 
-While base32 (the current default encoding used in subdomains) is simpler than base36, it's not optimally efficient and base36 Ed25519 IPNS keys are 2 characters too big to fit into the 63 character subdomain length limit. The extra efficiency from base36 brings us under this limit and allows Ed25519 IPNS keys to work with the subdomain gateway.
+While base32 (the current default encoding used in subdomains) is simpler than base36, it’s not optimally efficient and base36 Ed25519 IPNS keys are 2 characters too big to fit into the 63 character subdomain length limit. The extra efficiency from base36 brings us under this limit and allows Ed25519 IPNS keys to work with the subdomain gateway.
 
-This release adds support for base36 but won't use it by default. If you'd like to re-encode an Ed25519 IPNS key into base36, you can use the `ipfs cid format` command:
+This release adds support for base36 but won’t use it by default. If you’d like to re-encode an Ed25519 IPNS key into base36, you can use the `ipfs cid format` command:
 
 ```sh
 $ ipfs cid format -v 1 --codec libp2p-key -b base36 bafzaajaiaejca4syrpdu6gdx4wsdnokxkprgzxf4wrstuc34gxw5k5jrag2so5gk
@@ -53,11 +53,11 @@ $ ipfs cid format -v 1 --codec libp2p-key -b base36 bafzaajaiaejca4syrpdu6gdx4ws
 
 ## 🕸️ Gossipsub upgraded to v1.1
 
-This release brings a new gossipsub protocol version: 1.1. You can read about it in the [blog post](https://blog.ipfs.io/2020-05-20-gossipsub-v1.1/).
+This release brings a new Gossipsub protocol version: 1.1. You can read about it in the [blog post](https://blog.ipfs.io/2020-05-20-gossipsub-v1.1/).
 
 ## 🤝 Peering
 
-This release introduces a new Peering feature. The peering subsystem configures go-ipfs to connect to, remain connected to, and reconnect to a set of nodes. Nodes should use this subsystem to create "sticky" links between frequently useful peers to improve reliability. You can read more about it and how to configure peers in the [go-ipfs config readme](https://github.com/ipfs/go-ipfs/blob/v0.6.0/docs/config.md#peering).
+This release introduces a new Peering feature. The peering subsystem configures go-ipfs to connect to, remain connected to, and reconnect to a set of nodes. Nodes should use this subsystem to create “sticky” links between frequently useful peers to improve reliability. You can read more about it and how to configure peers in the [go-ipfs config readme](https://github.com/ipfs/go-ipfs/blob/v0.6.0/docs/config.md#peering).
 
 
 ## Thank you contributors!

--- a/content/post/101-go-ipfs-0-6-0.md
+++ b/content/post/101-go-ipfs-0-6-0.md
@@ -47,7 +47,8 @@ While base32 (the current default encoding used in subdomains) is simpler than b
 This release adds support for base36 but won't use it by default. If you'd like to re-encode an Ed25519 IPNS key into base36, you can use the `ipfs cid format` command:
 
 ```sh
-$ ipfs cid format -v 1 --codec libp2p-key -b base36 bafzaajaiaejca4syrpdu6gdx4wsdnokxkprgzxf4wrstuc34gxw5k5jrag2so5gk k51qzi5uqu5dj16qyiq0tajolkojyl9qdkr254920wxv7ghtuwcz593tp69z9m
+$ ipfs cid format -v 1 --codec libp2p-key -b base36 bafzaajaiaejca4syrpdu6gdx4wsdnokxkprgzxf4wrstuc34gxw5k5jrag2so5gk
+# k51qzi5uqu5dj16qyiq0tajolkojyl9qdkr254920wxv7ghtuwcz593tp69z9m
 ```
 
 ## 🕸️ Gossipsub upgraded to v1.1

--- a/content/post/101-go-ipfs-0-6-0.md
+++ b/content/post/101-go-ipfs-0-6-0.md
@@ -1,0 +1,73 @@
+---
+date: 2020-06-26
+url: /2020-06-26-go-ipfs-0-6-0/
+title: IPFS 0.6.0 is here! QUIC, Noise, Peering and more!
+author: Jacob Heun
+tags: go-ipfs, release
+---
+
+# 🔦 Go-IPFS 0.6.0 Highlights
+
+**MIGRATION:** This release contains a small config migration to enable listening on the QUIC transport in addition to the TCP transport. This migration will:
+
+* Normalize multiaddrs in the bootstrap list to use the `/p2p/Qm...` syntax for multiaddrs instead of the `/ipfs/Qm...` syntax.
+* Add QUIC addresses for the default bootstrappers, as necessary. If you've removed the default bootstrappers from your bootstrap config, the migration won't add them back.
+* Add a QUIC listener address to mirror any TCP addresses present in your config. For example, if you're listening on `/ip4/0.0.0.0/tcp/1234`, this migration will add a listen address for `/ip4/0.0.0.0/udp/1234/quic`.
+
+## 🚂 QUIC is now enabled by default
+
+This release enables the QUIC transport (draft 28) by default for both inbound and outbound connections. When connecting to new peers, libp2p will continue to dial all advertised addresses (tcp + quic) in parallel so if the QUIC connection fails for some reason, the connection should still succeed.
+
+If you want to learn more about the advantages of QUIC, check out the [release notes](https://github.com/ipfs/go-ipfs/releases/tag/v0.6.0) for more information.
+
+**NOTE:** The QUIC transport included in this release is backwards incompatible with the experimental QUIC transport included in previous releases. Unfortunately, the QUIC protocol underwent some significant breaking changes and supporting multiple versions wasn't an option. In practice this degrades gracefully as go-ipfs will simply fall back on the TCP transport when dialing nodes with incompatible QUIC versions.
+
+## 🔐 Introducing the Noise Security Transport
+
+This go-ipfs release introduces a new security transport: [libp2p Noise](https://github.com/libp2p/specs/tree/master/noise) (built from the [Noise Protocol Framework](http://www.noiseprotocol.org/)). While TLS1.3 remains the default go-ipfs security transport, Noise is simpler to implement from scratch and will be the standard cross-platform libp2p security transport going forward.
+
+This brings us one step closer to deprecating and removing support for SECIO.
+
+While enabled by default, TLS1.3 and SECIO will still be negotiated prior to Noise. Once the network has had time to upgrade, Noise will take priority over SECIO. If you'd like to prefer Noise over other security transports, you can change its priority in the [config](https://github.com/ipfs/go-ipfs/blob/v0.6.0/docs/config.md#swarmtransportssecurity) (`Swarm.Transports.Security.Noise`).
+
+## 🚪Gateway
+
+This release brings two gateway-relevant features: custom 404 pages and base36 support.
+
+### 🚫Custom 404 pages
+
+You can now customize `404 Not Found` error pages by including an `ipfs-404.html` file somewhere in the request path. When a requested file isn't found, go-ipfs will look for an `ipfs-404.html` in the same directory as the requested file, and in each parent directory. If found, this file will be returned (with a 404 status code) instead of the usual error message.
+
+### 🗝️Base36 Support
+
+This release adds support for a new multibase encoding: base36. Base36 is an optimally efficient case-insensitive alphanumeric encoding. Case-insensitive alphanumeric encodings are important for the subdomain gateway as domain names are case insensitive.
+
+While base32 (the current default encoding used in subdomains) is simpler than base36, it's not optimally efficient and base36 Ed25519 IPNS keys are 2 characters too big to fit into the 63 character subdomain length limit. The extra efficiency from base36 brings us under this limit and allows Ed25519 IPNS keys to work with the subdomain gateway.
+
+This release adds support for base36 but won't use it by default. If you'd like to re-encode an Ed25519 IPNS key into base36, you can use the `ipfs cid format` command:
+
+```sh
+$ ipfs cid format -v 1 --codec libp2p-key -b base36 bafzaajaiaejca4syrpdu6gdx4wsdnokxkprgzxf4wrstuc34gxw5k5jrag2so5gk k51qzi5uqu5dj16qyiq0tajolkojyl9qdkr254920wxv7ghtuwcz593tp69z9m
+```
+
+## 🕸️ Gossipsub upgraded to v1.1
+
+This release brings a new gossipsub protocol version: 1.1. You can read about it in the [blog post](https://blog.ipfs.io/2020-05-20-gossipsub-v1.1/).
+
+## 🤝 Peering
+
+This release introduces a new Peering feature. The peering subsystem configures go-ipfs to connect to, remain connected to, and reconnect to a set of nodes. Nodes should use this subsystem to create "sticky" links between frequently useful peers to improve reliability. You can read more about it and how to configure peers in the [go-ipfs config readme](https://github.com/ipfs/go-ipfs/blob/v0.6.0/docs/config.md#peering).
+
+
+## Thank you contributors!
+
+A huge thank you to [everyone who contributed](https://github.com/ipfs/go-ipfs/blob/master/CHANGELOG.md#contributors) patches and improvements in this release, all **46** of you! We couldn’t have made this happen without your help and feedback. ❤
+
+## Want to learn more...or even, better get involved?
+
+You can get started by [installing go-ipfs](https://dist.ipfs.io/#go-ipfs) or [upgrading to go-ipfs 0.6](https://docs.ipfs.io/recent-releases/go-ipfs-0-6/update-procedure).
+
+And, of course, there are many other ways to get involved with IPFS based on your skill set, interest, and availability.  Please check out [our contribution page](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md) on GitHub for guidance and next steps.
+
+This is an exciting time for IPFS and the web in general. Join us!
+

--- a/content/post/101-go-ipfs-0-6-0.md
+++ b/content/post/101-go-ipfs-0-6-0.md
@@ -30,15 +30,15 @@ This brings us one step closer to deprecating and removing support for SECIO.
 
 While enabled by default, TLS1.3 and SECIO will still be negotiated prior to Noise. Once the network has had time to upgrade, Noise will take priority over SECIO. If you'd like to prefer Noise over other security transports, you can change its priority in the [config](https://github.com/ipfs/go-ipfs/blob/v0.6.0/docs/config.md#swarmtransportssecurity) (`Swarm.Transports.Security.Noise`).
 
-## 🚪Gateway
+## 🚪 Gateway
 
 This release brings two gateway-relevant features: custom 404 pages and base36 support.
 
-### 🚫Custom 404 pages
+### 🚫 Custom 404 pages
 
 You can now customize `404 Not Found` error pages by including an `ipfs-404.html` file somewhere in the request path. When a requested file isn't found, go-ipfs will look for an `ipfs-404.html` in the same directory as the requested file, and in each parent directory. If found, this file will be returned (with a 404 status code) instead of the usual error message.
 
-### 🗝️Base36 Support
+### 🗝️ Base36 Support
 
 This release adds support for a new multibase encoding: base36. Base36 is an optimally efficient case-insensitive alphanumeric encoding. Case-insensitive alphanumeric encodings are important for the subdomain gateway as domain names are case insensitive.
 

--- a/content/post/101-go-ipfs-0-6-0.md
+++ b/content/post/101-go-ipfs-0-6-0.md
@@ -64,11 +64,10 @@ This release introduces a new Peering feature. The peering subsystem configures 
 
 A huge thank you to [everyone who contributed](https://github.com/ipfs/go-ipfs/blob/master/CHANGELOG.md#contributors) patches and improvements in this release, all **46** of you! We couldn’t have made this happen without your help and feedback. ❤
 
-## Want to learn more...or even, better get involved?
+## Install, upgrade, and join us!
 
 You can get started by [installing go-ipfs](https://dist.ipfs.io/#go-ipfs) or [upgrading to go-ipfs 0.6](https://docs.ipfs.io/recent-releases/go-ipfs-0-6/update-procedure).
 
-And, of course, there are many other ways to get involved with IPFS based on your skill set, interest, and availability.  Please check out [our contribution page](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md) on GitHub for guidance and next steps.
+There are many ways to get involved with IPFS based on your skill set, interest, and availability.  Please check out [our contribution page](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md) on GitHub for guidance and next steps.
 
 This is an exciting time for IPFS and the web in general. Join us!
-


### PR DESCRIPTION
This is a trimmed down, cleaned up version of the release notes. As we aim to release more often, the goal is to improve the pipeline from release notes to blog post. I'd like to have high level summaries here that give you enough info about what each feature/fix contains, with links to their more technical counterparts in the release notes /readmes.