### PR TITLE
Remove Google Analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
 baseURL = "https://blog.ipfs.io"
 relativeURLs = true
-googleAnalytics = "UA-52930282-2"
 ignoreFiles = [ "\\.js\\.tmp*"]
 
 DefaultContentLanguage = "en"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -52,4 +52,3 @@
 <script src="/asciinema/asciinema-player.js"></script>
 <script src="/highlight/highlight.js"></script>
 <script>hljs.initHighlightingOnLoad()</script>
-{{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
Hello, IPFS team!

Google have been known for censoring opinions and facts through centralisation.

To me, this seems orthoganal to the goals of the IPFS project -- a decentralised technology that could change how we consume information.

Since Google are also known for their horrendous privacy and general hostility towards people that speak out against them, I personally think this, and many other projects, would benefit if they were no longer under the influence of Google.

To date, we have seen too many injustices that have ultimately stemmed through Google, and the general theme is either: privacy issues; censorship; hostility towards journalists that challenge this monopoly; the monopolisation and dystopian vision held within Google.

By using Google Analytics, it could be said that this vision is being supported by good-intentioned FOSS developers. Sadly, many FOSS developers have not come to terms with how much they rely on Google yet, but hopefully that will change over time, as more and more alternatives continue to appear.

Is this the company you want to support? If not, there are alternatives listed here: https://switching.software/replace/google-analytics/

---

Another question I have is if we could find a way to replace Google Forms with a FOSS solution, which does not gather intelligence on normal users for an advertising agency.

[There are some viable alternatives, too.](https://switching.software/replace/google-forms/)