### PR TITLE
Add URI alias for 0.8 release post

### DIFF
--- a/content/post/125-go-ipfs-0-8-0.md
+++ b/content/post/125-go-ipfs-0-8-0.md
@@ -1,6 +1,8 @@
 ---
 date: 2021-02-19
-url: /2021-02-19-go-ipfs-0-6-0/
+url: /2021-02-19-go-ipfs-0-8-0/
+aliases:
+    - /2021-02-19-go-ipfs-0-6-0/
 title: go-ipfs 0.8.0, and Remote Pinning, is here!
 author: Adin Schmahmann
 tags: ipfs, go-ipfs, release notes


### PR DESCRIPTION
URI typo fix:
`https://blog.ipfs.io/2021-02-19-go-ipfs-0-6-0/` will alias over to `https://blog.ipfs.io/2021-02-19-go-ipfs-0-8-0/`